### PR TITLE
display name of single workspace

### DIFF
--- a/apps/operator/src/components/shared/workspace-selector/workspace-selector.tsx
+++ b/apps/operator/src/components/shared/workspace-selector/workspace-selector.tsx
@@ -76,11 +76,24 @@ export const WorkspaceSelector = () => {
     }
   }
 
-  // if there is only one non-personal workspace, show the logo instead of the dropdown
-  if (nonPersonalOrgs.length <= 1) {
+  // if there are no workspaces, return the logo
+  if (nonPersonalOrgs.length === 0) {
     return (
       <Link href={'/'} className={logoWrapper()}>
         <Logo width={115} theme="dark" />
+      </Link>
+    )
+  }
+
+  // if there is only one workspace, return the logo with the workspace name
+  if (nonPersonalOrgs.length === 1) {
+    return (
+      <Link href={'/'} className={logoWrapper()}>
+        <Logo width={30} asIcon theme="blackberryLight" />
+        <div>
+          <div className={workspaceLabel()}>Workspace:</div>
+          <span>{activeOrg?.displayName}</span>
+        </div>
       </Link>
     )
   }


### PR DESCRIPTION
if all you have is a personal org, it will display the logo:

![image](https://github.com/user-attachments/assets/e7d26794-5ac8-4c96-b1be-455d01476f83)

if you have one workspace, it will display the name but no dropdown:

![image](https://github.com/user-attachments/assets/0a4bb9c6-7ac7-4502-82b5-f14251f3cb5f)

More than that, it will display the dropdown:

![image](https://github.com/user-attachments/assets/245bead7-91d9-459c-87f9-854c63076dd6)

relates to: https://github.com/datumforge/datum-ui/issues/213
