### PR TITLE
Add repository.url to package.json

### DIFF
--- a/packages/datum-ui/package.json
+++ b/packages/datum-ui/package.json
@@ -7,6 +7,9 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
+  "repository": {
+    "url": "https://github.com/datum-cloud/datum-ui"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
repository.url is required for npm publishing this change adds it to the repo