### PR TITLE
fix: add getServerSnapshot to useSyncExternalStore calls for SSR comp…

### DIFF
--- a/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-client.ts
+++ b/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-client.ts
@@ -77,7 +77,7 @@ export function useDataTableClient<TData>(options: UseDataTableClientOptions<TDa
 
   // 4. Read store state for TanStack table
   const { filteredData, sorting, rowSelection, pageIndex, pageSize: storePageSize, filters, search }
-    = useSyncExternalStore(store.subscribe, store.getSnapshot)
+    = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
 
   // 5. Create TanStack table (sort + paginate only, no filtering)
   const table = useReactTable({

--- a/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-server.ts
+++ b/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-server.ts
@@ -88,7 +88,7 @@ export function useDataTableServer<TResponse, TData>(
 
   // 2. Read store state
   const { sorting, filters, search, rowSelection, pageSize, pageIndex }
-    = useSyncExternalStore(store.subscribe, store.getSnapshot)
+    = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
 
   // 3. Fetch on query change — also resets cursors when query params change
   const prevQueryRef = useRef({ sorting, filters, search, pageSize })

--- a/packages/datum-ui/src/components/features/data-table/hooks/use-selectors.ts
+++ b/packages/datum-ui/src/components/features/data-table/hooks/use-selectors.ts
@@ -45,7 +45,7 @@ function useSliceSelector<TData, TSlice extends Record<string, unknown>>(
     return next
   }, [store, selector])
 
-  return useSyncExternalStore(store.subscribe, getSnapshot)
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot)
 }
 
 export function useDataTableFilters() {
@@ -166,7 +166,7 @@ export function useDataTableInlineContents<TData>() {
 export function useDataTableContext<TData>() {
   const store = useDataTableStore<TData>()
   const table = useTableInstance<TData>()
-  const state = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  const state = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
   return {
     table,
     mode: state.mode,


### PR DESCRIPTION
…atibility

Pass getServerSnapshot (3rd arg) to all useSyncExternalStore calls in the data-table hooks to fix "Missing getServerSnapshot" error during server-side rendering