### PR TITLE
fix(ci): specify pnpm version in action-setup to fix workflow failures

### DIFF
--- a/packages/datum-ui/package.json
+++ b/packages/datum-ui/package.json
@@ -2,6 +2,7 @@
   "name": "@datum-cloud/datum-ui",
   "type": "module",
   "version": "0.2.1",
+  "packageManager": "pnpm@10.28.1",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/datum-cloud/datum-ui"


### PR DESCRIPTION
pnpm/action-setup@v4 requires an explicit version when it cannot auto-detect from package.json packageManager field. Add version: 10 to all pnpm/action-setup steps across CI, release, and publish workflows.
