### PR TITLE
fix(ci): pass monorepo lockfile and install paths to publish workflow

### DIFF
--- a/.github/workflows/publish-datum-ui.yml
+++ b/.github/workflows/publish-datum-ui.yml
@@ -23,6 +23,8 @@ jobs:
     with:
       package-name: "@datum-cloud/datum-ui"
       package-path: packages/datum-ui
+      lockfile-path: pnpm-lock.yaml
+      install-path: "."
 
   # Alpha publish on PR with 'alpha' label
   alpha:


### PR DESCRIPTION
The reusable publish-npm-package workflow now supports lockfile-path and install-path inputs. Pass these so it finds pnpm-lock.yaml at the repo root and runs pnpm install from the root, matching the monorepo layout.