### PR TITLE
feat: add separate storybook release cycle

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@repo/storybook", "@repo/docs"]
+  "ignore": ["@repo/docs"]
 }

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -3,13 +3,7 @@ name: Publish Storybook
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/storybook/**'
-      - 'packages/datum-ui/**'
-      - 'packages/shadcn/**'
-
-  release:
-    types: ["published"]
+    tags: ['storybook-v*']
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
       pull-requests: write
@@ -75,3 +77,33 @@ jobs:
             --body "${{ steps.pr-body.outputs.body }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  tag-storybook:
+    name: Tag Storybook Release
+    needs: [release]
+    if: needs.release.outputs.hasChangesets == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check and create storybook tag
+        run: |
+          VERSION=$(node -p "require('./apps/storybook/package.json').version")
+          TAG="storybook-v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created and pushed $TAG"
+          fi

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -1,0 +1,38 @@
+# Datum Storybook
+
+Interactive component documentation for the [Datum design system](https://www.npmjs.com/package/@datum-cloud/datum-ui). Browse, test, and explore all UI components with live examples and controls.
+
+## Getting Started
+
+```bash
+# Install dependencies (from repo root)
+pnpm install
+
+# Start dev server
+pnpm --filter @repo/storybook dev
+```
+
+Open [http://localhost:6006](http://localhost:6006) to view the Storybook.
+
+## Scripts
+
+| Command                                   | Description              |
+| ----------------------------------------- | ------------------------ |
+| `pnpm --filter @repo/storybook dev`       | Start development server |
+| `pnpm --filter @repo/storybook build`     | Build static site        |
+| `pnpm --filter @repo/storybook lint`      | Run ESLint               |
+| `pnpm --filter @repo/storybook typecheck` | Run TypeScript checks    |
+
+## Writing Stories
+
+Stories live in `stories/` organized by category:
+
+- **`stories/base/`** — Core components (Button, Input, Card, etc.)
+- **`stories/features/`** — Composite components (DataTable, Form, Dropzone, etc.)
+- **`stories/helpers/`** — Shared decorators and mock data
+
+Each story file follows the [Component Story Format (CSF)](https://storybook.js.org/docs/api/csf).
+
+## Contributing
+
+See the [release guide](./RELEASE.md) for how staging and production deployments work.

--- a/apps/storybook/RELEASE.md
+++ b/apps/storybook/RELEASE.md
@@ -1,0 +1,37 @@
+# Storybook Release Guide
+
+## Staging (automatic)
+
+Merging to `main` with changes in `apps/storybook/`, `packages/datum-ui/`,
+or `packages/shadcn/` automatically publishes a pre-release build to staging.
+
+## Production
+
+1. Create a changeset:
+
+   ```bash
+   pnpm changeset
+   ```
+
+   Select `@repo/storybook` and choose the bump type (patch/minor/major).
+
+2. Commit the changeset and merge your PR to `main`.
+
+3. The "Version Packages" PR is created automatically. Review and merge it.
+
+4. On merge, a `storybook-v{version}` git tag is created and the
+   production build is published automatically.
+
+## Environments
+
+| Environment | URL                             | Trigger           |
+| ----------- | ------------------------------- | ----------------- |
+| Staging     | storybook.staging.env.datum.net | Push to main      |
+| Production  | storybook.datum.net             | storybook-v\* tag |
+
+## Architecture
+
+- **Docker image:** `ghcr.io/datum-cloud/datum-storybook`
+- **OCI kustomize bundle:** `ghcr.io/datum-cloud/datum-storybook-kustomize`
+- **Deployment:** FluxCD GitOps via [datum-cloud/infra](https://github.com/datum-cloud/infra)
+- **Container:** Nginx serving static build on port 8080

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/storybook",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "predev": "[ -d '../../packages/datum-ui/dist' ] || pnpm --filter @datum-cloud/datum-ui build",


### PR DESCRIPTION
## Summary

- Give storybook its own Changesets versioning cycle, independent from datum-ui
- Add automated `storybook-v{version}` git tag creation for production deployments
- Replace broken `release:published` trigger with clean semver tag push trigger

Ref: https://github.com/datum-cloud/datum-ui/issues/52

## Changes

| File | Change |
|------|--------|
| `.changeset/config.json` | Remove `@repo/storybook` from ignore list |
| `apps/storybook/package.json` | Set initial version to `0.1.0` |
| `.github/workflows/release.yml` | Add `tag-storybook` job with git identity config |
| `.github/workflows/publish-storybook.yml` | Replace `release:published` with `storybook-v*` tag trigger, remove `paths` filter |
| `apps/storybook/README.md` | Public-facing intro and dev guide |
| `apps/storybook/RELEASE.md` | Internal release and deployment guide |

## How it works

```
pnpm changeset → select @repo/storybook → merge PR
  → "Version Packages" PR bumps apps/storybook/package.json
  → merge version PR → tag-storybook job creates storybook-v0.1.0
  → publish-storybook.yml fires → Docker + OCI bundle with clean semver
  → FluxCD production picks up via semver: >= 0.0.0
```