### PR TITLE
Add changeset for @repo/storybook major release

### DIFF
--- a/.changeset/public-turtles-cut.md
+++ b/.changeset/public-turtles-cut.md
@@ -1,0 +1,5 @@
+---
+"@repo/storybook": major
+---
+
+Transforms the Storybook setup from a basic development tool into a production-quality component documentation and exploration platform for both internal developers and external npm consumers.

--- a/apps/storybook/Dockerfile
+++ b/apps/storybook/Dockerfile
@@ -21,9 +21,8 @@ RUN pnpm --filter @repo/storybook build
 
 FROM joseluisq/static-web-server:2-alpine
 COPY --from=builder /app/apps/storybook/storybook-static /public
-ENV SERVER_PORT=8080
-ENV SERVER_ROOT=/public
-ENV SERVER_FALLBACK_PAGE=/public/index.html
+COPY apps/storybook/sws.toml /etc/sws/config.toml
+ENV SERVER_CONFIG_FILE=/etc/sws/config.toml
 
 # Run as non-root user (sws default user)
 USER 1000

--- a/apps/storybook/sws.toml
+++ b/apps/storybook/sws.toml
@@ -5,8 +5,10 @@ page-fallback = "/public/index.html"
 log-level = "info"
 
 [advanced]
+
 [[advanced.headers]]
 source = "**/*"
+
 [advanced.headers.headers]
 X-Frame-Options = ""
 Content-Security-Policy = "frame-ancestors 'self' https://*.datum.net"

--- a/apps/storybook/sws.toml
+++ b/apps/storybook/sws.toml
@@ -1,0 +1,12 @@
+[general]
+port = 8080
+root = "/public"
+page-fallback = "/public/index.html"
+log-level = "info"
+
+[advanced]
+[[advanced.headers]]
+source = "**/*"
+[advanced.headers.headers]
+X-Frame-Options = ""
+Content-Security-Policy = "frame-ancestors 'self' https://*.datum.net"


### PR DESCRIPTION
Create .changeset/public-turtles-cut.md to mark @repo/storybook for a major version bump. The changeset describes converting the Storybook setup into a production-quality component documentation and exploration platform for both internal developers and external npm consumers, ensuring the change is included in the next release.