### PR TITLE
fix: use GIT_PAT for storybook production releases

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -3,7 +3,9 @@ name: Publish Storybook
 on:
   push:
     branches: [main]
-    tags: ['storybook-v*']
+
+  release:
+    types: ["published"]
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,32 +78,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  tag-storybook:
-    name: Tag Storybook Release
+  release-storybook:
+    name: Release Storybook
     needs: [release]
     if: needs.release.outputs.hasChangesets == 'false'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Check and create storybook tag
+      - name: Create storybook release
         run: |
           VERSION=$(node -p "require('./apps/storybook/package.json').version")
           TAG="storybook-v${VERSION}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
           else
-            git tag "$TAG"
-            git push origin "$TAG"
-            echo "Created and pushed $TAG"
+            gh release create "$TAG" --title "$TAG" --generate-notes
+            echo "Created release $TAG"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PAT }}


### PR DESCRIPTION
## Summary

Fix storybook production deployment by using `GIT_PAT` to create GitHub Releases instead of pushing git tags with `GITHUB_TOKEN`.

**Root cause:** `GITHUB_TOKEN` events don't trigger downstream workflows ([GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). The `storybook-v*` tag push from the release job never triggered the publish workflow.

**Fix:** Match the cloud-portal pattern — create a proper GitHub Release using `GIT_PAT`, which triggers `release: published` on `publish-storybook.yml`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replace `tag-storybook` job with `release-storybook` using `gh release create` + `GIT_PAT` |
| `.github/workflows/publish-storybook.yml` | Restore `release: published` trigger, remove `tags: storybook-v*` |
| `.github/workflows/test-storybook-release.yml` | **Temporary** — test workflow to verify `GIT_PAT` works (delete after testing) |