### PR TITLE
fix: switch to manual GitHub Release for storybook production

### DIFF
--- a/.changeset/test-storybook-release.md
+++ b/.changeset/test-storybook-release.md
@@ -1,0 +1,5 @@
+---
+'@repo/storybook': patch
+---
+
+test production release flow with GIT_PAT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
       pull-requests: write
@@ -77,25 +75,3 @@ jobs:
             --body "${{ steps.pr-body.outputs.body }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release-storybook:
-    name: Release Storybook
-    needs: [release]
-    if: needs.release.outputs.hasChangesets == 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Create storybook release
-        run: |
-          VERSION=$(node -p "require('./apps/storybook/package.json').version")
-          TAG="storybook-v${VERSION}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists, skipping"
-          else
-            gh release create "$TAG" --title "$TAG" --generate-notes
-            echo "Created release $TAG"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GIT_PAT }}

--- a/apps/storybook/RELEASE.md
+++ b/apps/storybook/RELEASE.md
@@ -19,15 +19,20 @@ or `packages/shadcn/` automatically publishes a pre-release build to staging.
 
 3. The "Version Packages" PR is created automatically. Review and merge it.
 
-4. On merge, a `storybook-v{version}` git tag is created and the
-   production build is published automatically.
+4. Create a GitHub Release manually:
+   - Go to [Releases](https://github.com/datum-cloud/datum-ui/releases/new)
+   - Tag: `storybook-v{version}` (e.g., `storybook-v1.0.1`)
+   - Target: `main`
+   - Click "Publish release"
+
+5. The `release: published` event triggers the publish workflow automatically.
 
 ## Environments
 
 | Environment | URL                             | Trigger           |
 | ----------- | ------------------------------- | ----------------- |
 | Staging     | storybook.staging.env.datum.net | Push to main      |
-| Production  | storybook.datum.net             | storybook-v\* tag |
+| Production  | storybook.prod.env.datum.net    | GitHub Release    |
 
 ## Architecture
 

--- a/apps/storybook/RELEASE.md
+++ b/apps/storybook/RELEASE.md
@@ -29,10 +29,10 @@ or `packages/shadcn/` automatically publishes a pre-release build to staging.
 
 ## Environments
 
-| Environment | URL                             | Trigger           |
-| ----------- | ------------------------------- | ----------------- |
-| Staging     | storybook.staging.env.datum.net | Push to main      |
-| Production  | storybook.prod.env.datum.net    | GitHub Release    |
+| Environment | URL                             | Trigger        |
+| ----------- | ------------------------------- | -------------- |
+| Staging     | storybook.staging.env.datum.net | Push to main   |
+| Production  | storybook.prod.env.datum.net    | GitHub Release |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Remove the automated `release-storybook` job (`GIT_PAT` lacks release permissions). Switch to manual GitHub Release, matching the cloud-portal pattern.

## Production release flow

1. Changesets bumps storybook version via "Version Packages" PR
2. Merge version PR
3. Go to GitHub Releases → create `storybook-v{version}` tag targeting `main`
4. `release: published` triggers `publish-storybook.yml` → clean semver → FluxCD picks it up

## Changes

- `.github/workflows/release.yml` — remove `release-storybook` job and `outputs`
- `apps/storybook/RELEASE.md` — update docs with manual release steps