### PR TITLE
fix: use v{version} tag format for storybook releases

### DIFF
--- a/apps/storybook/RELEASE.md
+++ b/apps/storybook/RELEASE.md
@@ -21,7 +21,7 @@ or `packages/shadcn/` automatically publishes a pre-release build to staging.
 
 4. Create a GitHub Release manually:
    - Go to [Releases](https://github.com/datum-cloud/datum-ui/releases/new)
-   - Tag: `storybook-v{version}` (e.g., `storybook-v1.0.1`)
+   - Tag: `v{version}` (e.g., `v1.0.1`)
    - Target: `main`
    - Click "Publish release"
 


### PR DESCRIPTION
## Summary

`storybook-v1.0.1` is not valid semver — `docker/metadata-action` can't parse it. Use `v1.0.1` format instead, matching the cloud-portal pattern.

## After merge

1. Delete the old broken release: `storybook-v1.0.1`
2. Create new release with tag `v1.0.1` targeting `main`
3. Verify `publish-storybook.yml` produces clean semver tags