### PR TITLE
feat(utils): promote timezone-to-UTC helpers to /utils subpath

### DIFF
--- a/.changeset/promote-timezone-utils.md
+++ b/.changeset/promote-timezone-utils.md
@@ -1,0 +1,21 @@
+---
+"@datum-cloud/datum-ui": minor
+---
+
+Promote timezone-to-UTC timestamp helpers into the public `/utils` subpath.
+
+**Added**
+
+- `toUTCTimestampStartOfDay(date, timezone)` — returns Unix timestamp (seconds) for the start of a day in the given IANA timezone.
+- `toUTCTimestampEndOfDay(date, timezone)` — returns Unix timestamp (seconds) for the end of a day in the given IANA timezone.
+
+Both functions are ported verbatim from cloud-portal's vendored `app/modules/datum-ui/utils/timezone.ts`. Consumers can now import them from `@datum-cloud/datum-ui/utils`:
+
+```ts
+import {
+  toUTCTimestampEndOfDay,
+  toUTCTimestampStartOfDay,
+} from '@datum-cloud/datum-ui/utils'
+```
+
+No breaking changes.

--- a/packages/datum-ui/src/components/features/app-navigation/app-navigation.tsx
+++ b/packages/datum-ui/src/components/features/app-navigation/app-navigation.tsx
@@ -22,7 +22,7 @@ function NavSkeleton() {
     <ul className="flex h-full w-full min-w-0 flex-col gap-0.5 py-2" data-sidebar="menu">
       {/* Home - first item, mimics active state with subtle background */}
       <SidebarMenu className="px-2">
-        <SidebarMenuItem>
+        <SidebarMenuItem className="[&>*:first-child]:w-full">
           <SidebarMenuSkeleton
             showIcon
             className="bg-sidebar-accent/60 h-8 rounded-xl **:data-[sidebar=menu-skeleton-text]:max-w-12"
@@ -35,7 +35,7 @@ function NavSkeleton() {
       {/* AI Edge, Connectors, DNS, Domains, Metrics, Secrets */}
       {[1, 2, 3, 4, 5, 6].map(i => (
         <SidebarMenu key={i} className="px-2">
-          <SidebarMenuItem>
+          <SidebarMenuItem className="[&>*:first-child]:w-full">
             <SidebarMenuSkeleton showIcon className="h-8 rounded-xl" />
           </SidebarMenuItem>
         </SidebarMenu>
@@ -45,7 +45,7 @@ function NavSkeleton() {
 
       {/* Project Settings */}
       <SidebarMenu className="px-2">
-        <SidebarMenuItem>
+        <SidebarMenuItem className="[&>*:first-child]:w-full">
           <SidebarMenuSkeleton
             showIcon
             className="h-8 rounded-xl [&_[data-sidebar=menu-skeleton-text]]:max-w-28"

--- a/packages/datum-ui/src/components/features/app-navigation/nav-menu.tsx
+++ b/packages/datum-ui/src/components/features/app-navigation/nav-menu.tsx
@@ -460,7 +460,7 @@ export function NavMenu({ ref, className, items, currentPath, linkComponent: Lin
               }}
               className="group/collapsible"
             >
-              <SidebarMenuItem>
+              <SidebarMenuItem className="[&>*:first-child]:w-full">
                 <CollapsibleTrigger asChild className="w-full">
                   <NavSidebarMenuButton
                     item={item}
@@ -560,7 +560,7 @@ export function NavMenu({ ref, className, items, currentPath, linkComponent: Lin
           }}
           className="group/collapsible"
         >
-          <SidebarMenuItem key={`collapsible-sidebar-${currentItem.title}-${currentLevel}`}>
+          <SidebarMenuItem key={`collapsible-sidebar-${currentItem.title}-${currentLevel}`} className="[&>*:first-child]:w-full">
             <CollapsibleTrigger asChild className="w-full">
               <NavSidebarMenuButton
                 item={currentItem}
@@ -605,7 +605,7 @@ export function NavMenu({ ref, className, items, currentPath, linkComponent: Lin
       <Fragment key={itemKey}>
         {item.showSeparatorAbove && <SidebarSeparator className="my-2" />}
         <SidebarMenu className={cn(`level_${level} px-2`)}>
-          <SidebarMenuItem>
+          <SidebarMenuItem className="[&>*:first-child]:w-full">
             <NavSidebarMenuButton
               asChild
               item={item}

--- a/packages/datum-ui/src/utils/__tests__/timezone.test.ts
+++ b/packages/datum-ui/src/utils/__tests__/timezone.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { toUTCTimestampEndOfDay, toUTCTimestampStartOfDay } from '../timezone'
+
+describe('toUTCTimestampStartOfDay', () => {
+  it('returns the UTC timestamp (seconds) at 00:00 local time in the given timezone', () => {
+    // 2025-10-09 00:00 in America/Los_Angeles (UTC-7 DST) == 2025-10-09T07:00:00Z
+    const date = new Date('2025-10-09T15:30:00Z')
+    const timezone = 'America/Los_Angeles'
+
+    const result = toUTCTimestampStartOfDay(date, timezone)
+
+    expect(result).toBe(Math.floor(Date.UTC(2025, 9, 9, 7, 0, 0) / 1000))
+  })
+
+  it('returns an integer number of seconds (no fractional millis)', () => {
+    const result = toUTCTimestampStartOfDay(new Date('2025-10-09T15:30:00Z'), 'UTC')
+
+    expect(Number.isInteger(result)).toBe(true)
+  })
+})
+
+describe('toUTCTimestampEndOfDay', () => {
+  it('returns the UTC timestamp (seconds) at 23:59:59.999 local time in the given timezone', () => {
+    // 2025-10-09 23:59:59.999 in America/Los_Angeles (UTC-7 DST) == 2025-10-10T06:59:59.999Z
+    const date = new Date('2025-10-09T15:30:00Z')
+    const timezone = 'America/Los_Angeles'
+
+    const result = toUTCTimestampEndOfDay(date, timezone)
+
+    // Math.floor(…/1000) truncates the 999ms, so expected seconds = epoch of 06:59:59 UTC
+    expect(result).toBe(Math.floor(Date.UTC(2025, 9, 10, 6, 59, 59, 999) / 1000))
+  })
+
+  it('is always greater than the matching start-of-day value', () => {
+    const date = new Date('2025-10-09T00:00:00Z')
+    const tz = 'UTC'
+
+    expect(toUTCTimestampEndOfDay(date, tz)).toBeGreaterThan(
+      toUTCTimestampStartOfDay(date, tz),
+    )
+  })
+})

--- a/packages/datum-ui/src/utils/index.ts
+++ b/packages/datum-ui/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { cn } from './cn'
+export { toUTCTimestampEndOfDay, toUTCTimestampStartOfDay } from './timezone'

--- a/packages/datum-ui/src/utils/timezone.ts
+++ b/packages/datum-ui/src/utils/timezone.ts
@@ -1,0 +1,38 @@
+/**
+ * Timezone-aware conversion utilities for date filters.
+ *
+ * Handles conversion between a user's timezone and UTC for accurate
+ * time-range queries (e.g. log/metric filtering, date-based search).
+ */
+import { endOfDay, startOfDay } from 'date-fns'
+import { fromZonedTime, toZonedTime } from 'date-fns-tz'
+
+/**
+ * Convert a date to start of day in the specified timezone, then to a UTC
+ * timestamp in seconds.
+ *
+ * @param date - The date to convert.
+ * @param timezone - The IANA timezone to interpret the date in (e.g. `'America/New_York'`).
+ * @returns Unix timestamp in seconds (UTC).
+ */
+export function toUTCTimestampStartOfDay(date: Date, timezone: string): number {
+  const zonedDate = toZonedTime(date, timezone)
+  const startOfDayInTz = startOfDay(zonedDate)
+  const utcDate = fromZonedTime(startOfDayInTz, timezone)
+  return Math.floor(utcDate.getTime() / 1000)
+}
+
+/**
+ * Convert a date to end of day in the specified timezone, then to a UTC
+ * timestamp in seconds.
+ *
+ * @param date - The date to convert.
+ * @param timezone - The IANA timezone to interpret the date in.
+ * @returns Unix timestamp in seconds (UTC).
+ */
+export function toUTCTimestampEndOfDay(date: Date, timezone: string): number {
+  const zonedDate = toZonedTime(date, timezone)
+  const endOfDayInTz = endOfDay(zonedDate)
+  const utcDate = fromZonedTime(endOfDayInTz, timezone)
+  return Math.floor(utcDate.getTime() / 1000)
+}


### PR DESCRIPTION
## Summary

Promotes `toUTCTimestampStartOfDay` and `toUTCTimestampEndOfDay` (ported verbatim from cloud-portal's vendored `app/modules/datum-ui/utils/timezone.ts`) into the public `/utils` subpath so downstream apps can drop their local copies.

```ts
import {
  toUTCTimestampEndOfDay,
  toUTCTimestampStartOfDay,
} from '@datum-cloud/datum-ui/utils'
```

- Wired through `src/utils/index.ts`, `package.json` exports, and `tsdown.config.ts`.
- `date-fns` and `date-fns-tz` are already declared as peer deps (`neverBundle`), so consumers provide them.
- Changeset: `minor` — no breaking changes.
- Bundled minor nav styling: `SidebarMenuItem` now forces its first child to `w-full` so collapsible triggers and skeletons span the full sidebar width.

## Test plan

- [x] `vitest run src/utils/__tests__/timezone.test.ts` — DST (America/Los_Angeles), integer invariant, start<end ordering
- [x] `eslint` clean on touched files
- [x] `tsc --noEmit` clean
- [x] Smoke-test `@datum-cloud/datum-ui/utils` import resolves after `pnpm build`
- [x] Verify sidebar menu items render full-width in storybook