### PR TITLE
fix(data-table): stabilize useNuqsAdapter to prevent infinite loop

### DIFF
--- a/.changeset/data-table-server-infinite-loop.md
+++ b/.changeset/data-table-server-infinite-loop.md
@@ -1,0 +1,12 @@
+---
+"@datum-cloud/datum-ui": patch
+---
+
+Fix `<DataTable.Server>` infinite update loop when paired with `useNuqsAdapter()` or `useNuqsAdapter({})` (no filters configured). The placeholder parsers map used internally when no filter parsers are supplied was rebuilt on every render — including a fresh `parseAsString.withDefault('')` parser instance — which caused `useQueryStates` to re-subscribe and return a new setter ref each render. That ref churn cascaded into an unstable `StateAdapter` and re-fired the URL-write effect in `useServerTable`, producing a "Maximum update depth exceeded" crash on first render of any page that wanted URL-persisted search/pagination without filters.
+
+Two changes land together:
+
+- `useNuqsAdapter`: the empty-filters sentinel is now a module-scoped constant, so the parsers reference passed to `useQueryStates` is stable across renders and the returned `StateAdapter` is referentially stable.
+- `useServerTable`: the `stateAdapter` is captured in a ref and dropped from the URL-write `useEffect` deps, as defense-in-depth so a future adapter-stability regression cannot cascade into the same loop.
+
+Resolves #98.

--- a/packages/datum-ui/src/components/features/data-table/__tests__/nuqs-adapter-stability.test.ts
+++ b/packages/datum-ui/src/components/features/data-table/__tests__/nuqs-adapter-stability.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useNuqsAdapter } from '../adapters/nuqs-adapter'
+
+// Mock nuqs with a parsers-keyed cache so `useQueryStates` returns the same
+// [state, setter] tuple for the same parsers reference. This mirrors nuqs's
+// real behavior closely enough to assert ref stability across renders, which
+// is what issue #98 hinges on.
+
+const stateCache = new Map<object, readonly [Record<string, unknown>, (next: Record<string, unknown>) => void]>()
+
+function getStableTuple(parsers: Record<string, unknown>) {
+  const cached = stateCache.get(parsers)
+  if (cached)
+    return cached
+  // The mocked `withDefault` returns the default value directly, so
+  // `parsers[key]` is already the default we want to expose as state.
+  const state: Record<string, unknown> = {}
+  for (const key of Object.keys(parsers)) {
+    state[key] = parsers[key]
+  }
+  const setter = vi.fn()
+  const tuple = [state, setter] as const
+  stateCache.set(parsers, tuple)
+  return tuple
+}
+
+function mockUseQueryStates(parsers: Record<string, unknown>) {
+  return getStableTuple(parsers)
+}
+
+vi.mock('nuqs', () => ({
+  parseAsString: { withDefault: (d: unknown) => d },
+  parseAsInteger: { withDefault: (d: unknown) => d },
+  useQueryStates: mockUseQueryStates,
+}))
+
+describe('useNuqsAdapter — ref stability (issue #98)', () => {
+  it('returns the same StateAdapter ref across renders when called with no options', () => {
+    const { result, rerender } = renderHook(() => useNuqsAdapter())
+    const first = result.current
+    rerender()
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it('returns the same StateAdapter ref across renders when called with empty filters', () => {
+    const { result, rerender } = renderHook(() => useNuqsAdapter({}))
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it('returns the same StateAdapter ref across renders when stable filters are supplied', () => {
+    const stableFilters = { status: 'placeholder-parser' as unknown }
+    const { result, rerender } = renderHook(() => useNuqsAdapter({ filters: stableFilters }))
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/packages/datum-ui/src/components/features/data-table/adapters/nuqs-adapter.ts
+++ b/packages/datum-ui/src/components/features/data-table/adapters/nuqs-adapter.ts
@@ -63,6 +63,16 @@ const coreSearchParams = {
   size: parseAsInteger.withDefault(DEFAULT_PAGE_SIZE),
 }
 
+// Module-scoped placeholder used when the consumer provides no filter parsers.
+// Must be stable across renders — a fresh object literal or a fresh
+// `parseAsString.withDefault('')` parser instance on each render makes
+// `useQueryStates` re-subscribe and return a new setter ref each render,
+// which cascades into an unstable StateAdapter and can trigger an infinite
+// update loop in consumers that write the adapter on change (see issue #98).
+const EMPTY_FILTER_PARSERS_PLACEHOLDER = {
+  _dt: parseAsString.withDefault(''),
+}
+
 /**
  * Hook that creates a StateAdapter backed by nuqs URL query state.
  *
@@ -94,10 +104,11 @@ export function useNuqsAdapter(
 
   const hasFilters = filterParsers != null && Object.keys(filterParsers).length > 0
 
-  // Filters use a separate sentinel when empty to satisfy useQueryStates
+  // Filters use a separate sentinel when empty to satisfy useQueryStates.
+  // The sentinel must be a stable reference — see EMPTY_FILTER_PARSERS_PLACEHOLDER above.
   const resolvedFilterParsers = hasFilters
     ? filterParsers
-    : { _dt: parseAsString.withDefault('') }
+    : EMPTY_FILTER_PARSERS_PLACEHOLDER
   const [filterState, setFilterState] = useQueryStates(resolvedFilterParsers as Parameters<typeof useQueryStates>[0])
 
   return useMemo<StateAdapter>(

--- a/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-server.ts
+++ b/packages/datum-ui/src/components/features/data-table/hooks/use-data-table-server.ts
@@ -176,12 +176,17 @@ export function useServerTable<TResponse, TData>(
     },
   })
 
-  // 5. State adapter sync
+  // 5. State adapter sync.
+  // The adapter is captured in a ref so a churning adapter reference (e.g. a
+  // consumer hook that returns a new object each render) cannot cascade into
+  // this effect's deps and trigger an infinite write→re-render loop (issue #98).
+  const stateAdapterRef = useRef(stateAdapter)
   useEffect(() => {
-    if (stateAdapter) {
-      stateAdapter.write({ sorting, filters, search, pageSize })
-    }
-  }, [sorting, filters, search, pageSize, stateAdapter])
+    stateAdapterRef.current = stateAdapter
+  }, [stateAdapter])
+  useEffect(() => {
+    stateAdapterRef.current?.write({ sorting, filters, search, pageSize })
+  }, [sorting, filters, search, pageSize])
 
   return { table }
 }


### PR DESCRIPTION
## Summary

Resolves #98. `<DataTable.Server>` entered a "Maximum update depth exceeded" loop on first render when paired with `useNuqsAdapter()` or `useNuqsAdapter({})` (no filter parsers configured). Pages with non-empty `filters` config avoided the loop because they took the consumer-supplied parsers branch — that's why activity-list style pages worked but any no-filter server table immediately crashed.

## Root cause

Two cascading issues:

1. **`useNuqsAdapter` rebuilt the empty-filters sentinel on every render.** The inline `{ _dt: parseAsString.withDefault('') }` produced a fresh object **and** a fresh parser instance each render. `useQueryStates` saw a new parsers reference, returned a new `setFilterState`, and the wrapping `useMemo` produced a brand-new `StateAdapter` each render.
2. **`useServerTable` re-fired its URL-write effect on adapter ref change.** The effect listed `stateAdapter` in its deps, so the unstable adapter from (1) caused the effect to fire every render → URL update → re-render → infinite loop.

## Fix

- `useNuqsAdapter`: hoist `EMPTY_FILTER_PARSERS_PLACEHOLDER` to module scope so the parsers reference passed to `useQueryStates` is stable across renders.
- `useServerTable`: capture `stateAdapter` in a ref and drop it from the URL-write effect deps — defense-in-depth so a future adapter-stability regression cannot trigger the same loop.
- Add `nuqs-adapter-stability.test.ts` asserting `useNuqsAdapter()` returns the same `StateAdapter` reference across renders for the no-filter, empty-filter, and stable-filter cases.

## Test plan

- [x] `pnpm test` data-table suite passes (206 tests, including 3 new stability tests)
- [x] `pnpm typecheck` clean on both `@datum-cloud/datum-ui` and `@repo/storybook`
- [x] `pnpm lint` clean (no warnings)
- [ ] Smoke test downstream consumer: a server-side DataTable without `filters` config no longer crashes on first render