### PR TITLE
feat(empty-content)!: flexible action API — as-discriminated union with RBAC props

### DIFF
--- a/.changeset/empty-content-actions.md
+++ b/.changeset/empty-content-actions.md
@@ -1,0 +1,16 @@
+---
+"@datum-cloud/datum-ui": major
+---
+
+`EmptyContent` actions now use an `as`-discriminated union that forwards the full `Button`
+(and anchor) prop surface, plus RBAC-friendly `hidden` and `tooltip` props.
+
+Migration:
+
+- `type` (action kind) → `as` (`'button' | 'link' | 'external-link'`).
+- `variant: 'default' | 'destructive' | 'outline'` → Button's `type` + `theme`
+  (e.g. `destructive` → `type: 'danger'`; `outline` → `theme: 'outline'`).
+- `iconPosition: 'start' | 'end'` → `'left' | 'right'`.
+- New per-action props: `disabled`, `hidden`, `tooltip`, `tooltipSide`, and any other
+  `Button` prop (`loading`, `theme`, `block`, …).
+- Disabled `link`/`external-link` actions now render as a plain disabled button (no anchor).

--- a/apps/docs/content/docs/components/features/empty-content.mdx
+++ b/apps/docs/content/docs/components/features/empty-content.mdx
@@ -35,7 +35,7 @@ import { EmptyContent } from '@datum-cloud/datum-ui/empty-content'
     subtitle="Create your first project to get started."
     actions={[
       {
-        type: 'link',
+        as: 'link',
         label: 'Create Project',
         to: '#',
       },
@@ -49,7 +49,7 @@ import { EmptyContent } from '@datum-cloud/datum-ui/empty-content'
   subtitle="Create your first project to get started."
   actions={[
     {
-      type: 'button',
+      as: 'button',
       label: 'Create Project',
       onClick: () => console.log('Create clicked'),
     },
@@ -100,12 +100,12 @@ Actions can render as links or external links instead of buttons.
   title="no documentation yet."
   actions={[
     {
-      type: 'link',
+      as: 'link',
       label: 'View Docs',
       to: '/docs',
     },
     {
-      type: 'external-link',
+      as: 'external-link',
       label: 'GitHub',
       to: 'https://github.com/datum-cloud',
     },
@@ -130,12 +130,23 @@ Actions can render as links or external links instead of buttons.
 
 ### EmptyContentAction
 
+Actions are a discriminated union keyed on `as`. A `button` action accepts the full
+[`Button`](/docs/components/base/button) prop surface; `link` / `external-link` actions
+additionally accept anchor attributes plus `to`.
+
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `type` | `'button' \| 'link' \| 'external-link'` | -- | Action type |
+| `as` | `'button' \| 'link' \| 'external-link'` | `'button'` | Action kind (discriminator) |
 | `label` | `string` | -- | Button or link text |
-| `onClick` | `() => void` | -- | Click handler (for `button` type) |
-| `to` | `string` | -- | URL (for `link` and `external-link` types) |
-| `variant` | `'default' \| 'destructive' \| 'outline'` | -- | Button style variant |
+| `to` | `string` | -- | URL (required for `link` and `external-link`) |
+| `disabled` | `boolean` | `false` | Disables the action; a disabled link renders as a plain disabled button |
+| `hidden` | `boolean` | `false` | When true the action is not rendered (useful for RBAC) |
+| `tooltip` | `ReactNode` | -- | Tooltip shown on hover/focus (works while disabled) |
+| `tooltipSide` | `'top' \| 'right' \| 'bottom' \| 'left'` | -- | Tooltip placement |
+| `type` | `'primary' \| 'secondary' \| 'danger' \| …` | `'secondary'` | Button color/semantic type (any `Button` `type`) |
+| `theme` | `'solid' \| 'light' \| 'outline' \| …` | `'solid'` | Button theme (any `Button` `theme`) |
 | `icon` | `ReactNode` | -- | Icon element |
-| `iconPosition` | `'start' \| 'end'` | `'start'` | Icon placement |
+| `iconPosition` | `'left' \| 'right'` | `'left'` | Icon placement |
+| `onClick` | `(e) => void` | -- | Click handler |
+
+Any other [`Button`](/docs/components/base/button) prop (`loading`, `block`, …) is also accepted.

--- a/apps/storybook/stories/features/empty-content.stories.tsx
+++ b/apps/storybook/stories/features/empty-content.stories.tsx
@@ -38,3 +38,42 @@ export default meta
 type Story = StoryObj<typeof EmptyContent>
 
 export const Default: Story = {}
+
+export const WithActions: Story = {
+  args: {
+    actions: [
+      { as: 'button', label: 'Create item', type: 'primary' },
+      { as: 'link', label: 'Read the docs', to: '/docs' },
+    ],
+  },
+}
+
+export const ExternalLink: Story = {
+  args: {
+    actions: [
+      { as: 'external-link', label: 'Open status page', to: 'https://status.datum.net' },
+    ],
+  },
+}
+
+export const DisabledWithTooltip: Story = {
+  args: {
+    actions: [
+      {
+        as: 'button',
+        label: 'Create item',
+        disabled: true,
+        tooltip: 'You don\'t have permission to create items.',
+      },
+    ],
+  },
+}
+
+export const HiddenAction: Story = {
+  args: {
+    actions: [
+      { as: 'button', label: 'Visible action' },
+      { as: 'button', label: 'Hidden action', hidden: true },
+    ],
+  },
+}

--- a/packages/datum-ui/src/components/features/empty-content/__tests__/empty-content.test.tsx
+++ b/packages/datum-ui/src/components/features/empty-content/__tests__/empty-content.test.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { EmptyContent } from '../empty-content'
 
@@ -19,25 +19,148 @@ describe('emptyContent', () => {
     expect(screen.getByText('Try adjusting your filters')).toBeInTheDocument()
   })
 
-  it('renders action buttons', () => {
-    const handleClick = vi.fn()
-    render(
-      <EmptyContent
-        title="No data found"
-        actions={[
-          { type: 'button', label: 'Add Item', onClick: handleClick },
-          { type: 'link', label: 'Learn More', to: '/docs' },
-        ]}
-      />,
-    )
-    expect(screen.getByText('Add Item')).toBeInTheDocument()
-    expect(screen.getByText('Learn More')).toBeInTheDocument()
-  })
-
   it('merges custom className', () => {
     const { container } = render(
       <EmptyContent title="No data found" className="custom-class" />,
     )
     expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('renders button and link actions', () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyContent
+        title="No data found"
+        actions={[
+          { as: 'button', label: 'Add Item', onClick },
+          { as: 'link', label: 'Learn More', to: '/docs' },
+        ]}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Add Item' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Learn More' })).toBeInTheDocument()
+  })
+
+  it('fires onClick for button actions', () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyContent title="x" actions={[{ as: 'button', label: 'Add', onClick }]} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('renders external-link with target and rel', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[{ as: 'external-link', label: 'Ext', to: 'https://example.com' }]}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Ext' })
+    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders internal link with _self target', () => {
+    render(
+      <EmptyContent title="x" actions={[{ as: 'link', label: 'In', to: '/in' }]} />,
+    )
+    const link = screen.getByRole('link', { name: 'In' })
+    expect(link).toHaveAttribute('href', '/in')
+    expect(link).toHaveAttribute('target', '_self')
+  })
+
+  it('does not fire onClick when a button action is disabled', () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyContent
+        title="x"
+        actions={[{ as: 'button', label: 'Add', onClick, disabled: true }]}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Add' })
+    expect(btn).toBeDisabled()
+    fireEvent.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders a disabled link as a plain disabled button without an anchor', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[{ as: 'link', label: 'Go', to: '/x', disabled: true }]}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Go' })).toBeDisabled()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('does not leak anchor attributes onto a disabled link button', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[{ as: 'link', label: 'Go', to: '/x', disabled: true }]}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Go' })
+    expect(btn).not.toHaveAttribute('to')
+    expect(btn).not.toHaveAttribute('href')
+    expect(btn).not.toHaveAttribute('target')
+    expect(btn).not.toHaveAttribute('rel')
+  })
+
+  it('does not render hidden actions', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[
+          { as: 'button', label: 'Visible' },
+          { as: 'button', label: 'Secret', hidden: true },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Visible')).toBeInTheDocument()
+    expect(screen.queryByText('Secret')).not.toBeInTheDocument()
+  })
+
+  it('does not render the actions container when every action is hidden', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[{ as: 'button', label: 'Secret', hidden: true }]}
+      />,
+    )
+    expect(screen.queryByText('Secret')).not.toBeInTheDocument()
+  })
+
+  it('wraps the control in a hover target span so a disabled action can still show its tooltip', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[
+          { as: 'button', label: 'Locked', disabled: true, tooltip: 'No permission' },
+        ]}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Locked' })
+    // renderAction wraps the control in <span class="inline-flex"> before handing it
+    // to <Tooltip>, so the disabled button still has an element that receives hover.
+    expect(btn.closest('span.inline-flex')).not.toBeNull()
+  })
+
+  it('forwards Button props (icon and semantic type) to the underlying button', () => {
+    render(
+      <EmptyContent
+        title="x"
+        actions={[
+          { as: 'button', label: 'Delete', type: 'danger', icon: <svg data-testid="trash-icon" /> },
+        ]}
+      />,
+    )
+    expect(screen.getByTestId('trash-icon')).toBeInTheDocument()
+    // type='danger' + default theme='solid' compiles to the danger solid class.
+    expect(screen.getByRole('button', { name: 'Delete' }).className).toContain('bg-btn-danger')
   })
 })

--- a/packages/datum-ui/src/components/features/empty-content/empty-content.tsx
+++ b/packages/datum-ui/src/components/features/empty-content/empty-content.tsx
@@ -1,21 +1,38 @@
 import type { VariantProps } from 'class-variance-authority'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import type { ButtonProps } from '../../base/button/button'
 import { cva } from 'class-variance-authority'
+import { Fragment } from 'react'
 import { cn } from '../../../utils/cn'
 import { Button } from '../../base/button/button'
+import { Tooltip } from '../../base/tooltip/tooltip'
 import miloStamp from './assets/milo-stamp.svg'
 import scene5 from './assets/scene-5.png'
 import scene6 from './assets/scene-6.png'
 import scene7 from './assets/scene-7.png'
 
-export interface EmptyContentAction {
-  type: 'button' | 'link' | 'external-link'
+/** Shared by every action kind: full Button surface + presentation concerns. */
+interface BaseAction extends Omit<ButtonProps, 'asChild' | 'htmlType' | 'children'> {
   label: string
-  onClick?: () => void
-  to?: string
-  variant?: 'default' | 'destructive' | 'outline'
-  icon?: React.ReactNode
-  iconPosition?: 'start' | 'end'
+  /** Tooltip shown on hover/focus — pairs with `disabled` to explain why (RBAC). */
+  tooltip?: ReactNode
+  tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
+  /** Skip rendering entirely (e.g. no RBAC permission to even see it). */
+  hidden?: boolean
 }
+
+export interface ButtonAction extends BaseAction {
+  as?: 'button'
+}
+
+export interface LinkAction
+  extends BaseAction,
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | keyof BaseAction> {
+  as: 'link' | 'external-link'
+  to: string
+}
+
+export type EmptyContentAction = ButtonAction | LinkAction
 
 // Container variants
 const containerVariants = cva(
@@ -126,6 +143,19 @@ const BUTTON_SIZE_MAP = {
   xl: 'default',
 } as const
 
+// Button size back to the nearest container size (for actionButtonVariants text class)
+const BUTTON_SIZE_TO_CONTAINER: Record<
+  NonNullable<ButtonProps['size']>,
+  NonNullable<VariantProps<typeof actionButtonVariants>['size']>
+> = {
+  xs: 'xs',
+  small: 'sm',
+  default: 'lg',
+  large: 'xl',
+  icon: 'md',
+  link: 'md',
+}
+
 export interface EmptyContentProps extends VariantProps<typeof containerVariants> {
   title?: string
   subtitle?: string
@@ -152,52 +182,75 @@ export function EmptyContent({
 }: EmptyContentProps) {
   const buttonSize = BUTTON_SIZE_MAP[size ?? 'md']
   const LinkComp = linkComponent || 'a'
+  const visibleActions = actions.filter(action => !action.hidden)
 
   const renderAction = (action: EmptyContentAction) => {
-    const { icon: actionIcon, iconPosition = 'start' } = action
+    const renderAsLink
+      = (action.as === 'link' || action.as === 'external-link') && !action.disabled
 
-    const buttonContent = (
+    // Strip all non-Button keys (meta + anchor) so only Button props reach <Button>.
+    const {
+      as: _as,
+      label,
+      tooltip,
+      tooltipSide,
+      hidden: _hidden,
+      to,
+      target,
+      rel,
+      download,
+      hrefLang,
+      referrerPolicy,
+      ping,
+      type = 'secondary',
+      size: sizeOverride,
+      className: actionClassName,
+      ...buttonProps
+    } = action as ButtonAction & Partial<LinkAction>
+
+    const resolvedSize = sizeOverride ?? buttonSize
+    const wrapperSize = BUTTON_SIZE_TO_CONTAINER[resolvedSize ?? 'xs'] ?? 'md'
+
+    const button = (
       <Button
-        size={buttonSize}
-        type={action.variant === 'destructive' ? 'danger' : 'secondary'}
-        theme={action.variant === 'outline' ? 'outline' : 'solid'}
-        className={actionButtonVariants({ size })}
+        type={type}
+        size={resolvedSize}
+        className={cn(actionButtonVariants({ size: wrapperSize }), actionClassName)}
+        {...buttonProps}
       >
-        {actionIcon && iconPosition === 'start' && actionIcon}
-        <span>{action.label}</span>
-        {actionIcon && iconPosition === 'end' && actionIcon}
+        {label}
       </Button>
     )
 
-    if (action.type === 'link' || action.type === 'external-link') {
-      const linkProps = LinkComp === 'a' ? { href: action.to ?? '' } : { to: action.to ?? '' }
+    let control: ReactNode = button
 
-      return (
+    if (renderAsLink) {
+      const isExternal = action.as === 'external-link'
+      const linkHref = LinkComp === 'a' ? { href: to ?? '' } : { to: to ?? '' }
+      control = (
         <LinkComp
-          key={action.label}
-          {...linkProps}
-          target={action.type === 'external-link' ? '_blank' : '_self'}
-          rel={action.type === 'external-link' ? 'noopener noreferrer' : undefined}
+          {...linkHref}
+          target={target ?? (isExternal ? '_blank' : '_self')}
+          rel={isExternal ? 'noopener noreferrer' : rel}
+          download={download}
+          hrefLang={hrefLang}
+          referrerPolicy={referrerPolicy}
+          ping={ping}
         >
-          {buttonContent}
+          {button}
         </LinkComp>
       )
     }
 
-    return (
-      <Button
-        key={action.label}
-        size={buttonSize}
-        onClick={action.onClick}
-        type={action.variant === 'destructive' ? 'danger' : 'secondary'}
-        theme={action.variant === 'outline' ? 'outline' : 'solid'}
-        className={actionButtonVariants({ size })}
-      >
-        {actionIcon && iconPosition === 'start' && actionIcon}
-        <span>{action.label}</span>
-        {actionIcon && iconPosition === 'end' && actionIcon}
-      </Button>
-    )
+    if (tooltip) {
+      control = (
+        <Tooltip message={tooltip} side={tooltipSide}>
+          <span className="inline-flex">{control}</span>
+        </Tooltip>
+      )
+    }
+
+    return <Fragment key={`${action.as ?? 'button'}-${label}`}>{control}</Fragment>
   }
 
   return (
@@ -228,9 +281,9 @@ export function EmptyContent({
           {`Hey ${userName ?? 'there'}, ${title || ''}`}
         </h3>
         {subtitle && <span className={subtitleVariants({ size })}>{subtitle}</span>}
-        {actions.length > 0 && (
+        {visibleActions.length > 0 && (
           <div className={actionsContainerVariants({ size, spacing })}>
-            {actions.map(renderAction)}
+            {visibleActions.map(renderAction)}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Replaces the narrow `EmptyContentAction` shape with an **`as`-discriminated union** that forwards the full `Button` (and anchor) prop surface, and adds RBAC-friendly per-action `hidden`, `disabled`, and `tooltip` support.

- **`as` discriminator** (`'button' | 'link' | 'external-link'`) frees `type` to pass straight through to `Button`. A `button` action accepts the full `Button` prop surface; `link`/`external-link` actions additionally accept anchor attributes plus `to`.
- **First-class `disabled`** across all kinds. A disabled link **degrades to a plain disabled button** (anchors can't be natively disabled) — and anchor attributes never leak onto the `<button>`.
- **RBAC presentation primitives:** per-action `hidden` (skip render + suppress the empty container) and `tooltip` (+ `tooltipSide`). The tooltip wraps a `<span>` so the hint still shows while the control is disabled. The component stays RBAC-agnostic — the consumer computes `hidden`/`disabled`/`tooltip`.
- Default action styling (`type='secondary'`) and per-action `size` override preserved.

### Breaking change (major)

Migration (also in the changeset):
- `type` (action kind) → `as`
- `variant: 'default' | 'destructive' | 'outline'` → Button `type` + `theme` (e.g. `destructive` → `type: 'danger'`, `outline` → `theme: 'outline'`)
- `iconPosition: 'start' | 'end'` → `'left' | 'right'`
- New per-action props: `disabled`, `hidden`, `tooltip`, `tooltipSide`, and any other `Button` prop

Design spec and implementation plan included under `packages/datum-ui/docs/`.

## Test Plan

- [x] `pnpm vitest run` — 847/847 pass (15 in the EmptyContent suite, incl. disabled, hidden, tooltip hover-target, link target/rel, prop passthrough, and anchor-attr-leak regression)
- [x] `pnpm turbo run typecheck --filter=@datum-cloud/datum-ui` — clean
- [x] `pnpm turbo run lint --filter=@datum-cloud/datum-ui` — 0 errors
- [x] `pnpm turbo run build --filter=@datum-cloud/datum-ui` — succeeds
- [x] Storybook story typechecks; docs page updated to the new API
- [x] Visual check in Storybook (`WithActions`, `ExternalLink`, `DisabledWithTooltip`, `HiddenAction`)