### PR TITLE
chore(storybook): fix docs dark-mode container + changeset + reconcile version to 1.1.0

### DIFF
--- a/.changeset/storybook-docs-consolidation.md
+++ b/.changeset/storybook-docs-consolidation.md
@@ -1,0 +1,15 @@
+---
+"@repo/storybook": major
+---
+
+Consolidate all documentation into Storybook and remove the standalone fumadocs app.
+
+Storybook is now the single documentation surface:
+
+- Component usage docs (prose + examples) migrated into each story via `parameters.docs.description` and example stories.
+- MDX guide pages: Introduction, Installation, Theming, Providers, and the Picker migration guide.
+- Hook docs with live demos: `useCopyToClipboard`, `useDebounce`.
+- New stories for previously undocumented components: `StatCard`, `Combobox`, `Sidebar`.
+- Docs pages follow dark mode via a theme-aware `DocsContainer`.
+
+BREAKING CHANGE: the fumadocs app (`apps/docs`) has been removed.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/storybook",
   "type": "module",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "predev": "[ -d '../../packages/datum-ui/dist' ] || pnpm --filter @datum-cloud/datum-ui build",


### PR DESCRIPTION
## Summary

Follow-up to #112 (docs consolidation). Three related storybook items:

1. **Fix docs dark-mode** — the `ThemedDocsContainer` used `useGlobals()`, a Storybook preview hook that isn't valid in the docs container's render context and threw *"combining Storybook hooks with framework hooks"* at runtime. Now reads the active theme from the docs `context.globals` (no hooks); the docs page re-renders on global change, so it stays in sync.
2. **Add the missing `major` changeset** for `@repo/storybook` covering the docs-consolidation work (#112 shipped without one).
3. **Reconcile `apps/storybook/package.json` to `1.1.0`** to match the latest "Storybook" GitHub release, so the next "Version Packages" run bumps from the correct base.

`pnpm changeset status` → `@repo/storybook` queued for a **major** bump (`1.1.0 → 2.0.0`).

## Test plan

- [x] `pnpm --filter @repo/storybook typecheck` — passes
- [x] `pnpm --filter @repo/storybook build` — succeeds
- [x] `pnpm changeset status` confirms the major bump for `@repo/storybook`
- [ ] Visual: `storybook dev` — open a Docs tab, toggle the Theme toolbar; the docs page background/prose switch light↔dark with no console error