### PR TITLE
feat(grouped-table): collapsible grouped table with data-table parity

### DIFF
--- a/.changeset/grouped-table-data-table-parity.md
+++ b/.changeset/grouped-table-data-table-parity.md
@@ -1,0 +1,5 @@
+---
+'@datum-cloud/datum-ui': minor
+---
+
+GroupedTable: full data-table parity — sortable column headers, checkbox multi-select, per-row action menus, search, and loading/empty states, while keeping collapsible banded groups. Reuses data-table's selection column, column header, row actions, and search matcher.

--- a/.changeset/grouped-table.md
+++ b/.changeset/grouped-table.md
@@ -1,0 +1,5 @@
+---
+'@datum-cloud/datum-ui': minor
+---
+
+Add `GroupedTable` — a reusable collapsible grouped table with TanStack columns aligned across groups and a per-group header `meta` slot.

--- a/apps/storybook/stories/features/grouped-table.stories.tsx
+++ b/apps/storybook/stories/features/grouped-table.stories.tsx
@@ -1,0 +1,39 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import type { Meta, StoryObj } from 'storybook-react-rsbuild'
+import { Badge } from '@datum-cloud/datum-ui/badge'
+import { GroupedTable } from '@datum-cloud/datum-ui/grouped-table'
+
+interface Row { name: string, used: number, total: number, status: string }
+const columns: ColumnDef<Row, unknown>[] = [
+  { accessorKey: 'name', header: 'Resource', cell: i => i.getValue() as string, size: 220 },
+  { id: 'usage', header: 'Usage', cell: i => `${i.row.original.used} / ${i.row.original.total}` },
+  { accessorKey: 'status', header: 'Status', cell: i => i.getValue() as string, size: 140 },
+]
+const groups = [
+  { id: 'networking', title: 'Networking', meta: <Badge>1 near limit</Badge>, rows: [
+    { name: 'HTTP Proxies', used: 8, total: 10, status: 'Near limit' },
+    { name: 'Domains', used: 6, total: 25, status: 'Healthy' },
+  ] },
+  { id: 'dns', title: 'DNS', meta: <Badge>healthy</Badge>, rows: [
+    { name: 'DNS Zones', used: 4, total: 25, status: 'Healthy' },
+  ] },
+]
+
+const meta: Meta<typeof GroupedTable<Row>> = { title: 'Features/GroupedTable', component: GroupedTable }
+export default meta
+type Story = StoryObj<typeof GroupedTable<Row>>
+
+export const Default: Story = { args: { columns, groups } }
+export const Sortable: Story = { args: { columns, groups, enableSorting: true } }
+export const Selectable: Story = { args: { columns, groups, enableRowSelection: true, getRowId: (r: Row) => r.name } }
+export const WithRowActions: Story = { args: { columns, groups, rowActions: (row: Row) => [
+  { label: 'View', onClick: () => console.warn('view', row.name) },
+  { label: 'Edit', onClick: () => console.warn('edit', row.name) },
+] } }
+export const Searchable: Story = { args: { columns, groups, enableSearch: true, searchableColumns: ['name'], searchPlaceholder: 'Search resources' } }
+export const FullFeatured: Story = { args: { columns, groups, enableSorting: true, enableRowSelection: true, enableSearch: true, rowActions: (row: Row) => [
+  { label: 'View', onClick: () => console.warn('view', row.name) },
+  { label: 'Edit', onClick: () => console.warn('edit', row.name) },
+], getRowId: (r: Row) => r.name, searchableColumns: ['name'] } }
+export const Loading: Story = { args: { columns, groups, isLoading: true } }
+export const Empty: Story = { args: { columns, groups: [], empty: <div className="p-6 text-center text-sm text-muted-foreground">No data</div> } }

--- a/packages/datum-ui/package.json
+++ b/packages/datum-ui/package.json
@@ -194,6 +194,11 @@
       "types": "./dist/components/base/table/index.d.ts",
       "default": "./dist/table/index.mjs"
     },
+    "./grouped-table": {
+      "source": "./src/components/features/grouped-table/index.ts",
+      "types": "./dist/components/features/grouped-table/index.d.ts",
+      "default": "./dist/grouped-table/index.mjs"
+    },
     "./tabs": {
       "source": "./src/components/base/tabs/index.ts",
       "types": "./dist/components/base/tabs/index.d.ts",

--- a/packages/datum-ui/src/components/features/data-table/__tests__/barrel-exports.test.ts
+++ b/packages/datum-ui/src/components/features/data-table/__tests__/barrel-exports.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import * as DT from '../index'
+
+describe('data-table barrel reuse exports', () => {
+  it('exposes primitives reused by grouped-table', () => {
+    expect(typeof DT.createSelectionColumn).toBe('function')
+    expect(typeof DT.DataTableColumnHeader).toBe('function')
+    expect(typeof DT.DataTableRowActions).toBe('function')
+    expect(typeof DT.rowMatchesSearch).toBe('function')
+    expect(typeof DT.resolvePath).toBe('function')
+  })
+})

--- a/packages/datum-ui/src/components/features/data-table/__tests__/row-matches-search.test.ts
+++ b/packages/datum-ui/src/components/features/data-table/__tests__/row-matches-search.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { rowMatchesSearch } from '../core/filter-engine'
+
+interface Row { name: string, status: { label: string }, count: number }
+const row: Row = { name: 'HTTP Proxies', status: { label: 'Near limit' }, count: 8 }
+
+describe('rowMatchesSearch', () => {
+  it('returns true for empty query', () => {
+    expect(rowMatchesSearch(row, '', {})).toBe(true)
+  })
+  it('matches across all stringifiable values by default', () => {
+    expect(rowMatchesSearch(row, 'proxies', {})).toBe(true)
+    expect(rowMatchesSearch(row, '8', {})).toBe(true)
+    expect(rowMatchesSearch(row, 'zzz', {})).toBe(false)
+  })
+  it('honors searchableColumns with dot paths', () => {
+    expect(rowMatchesSearch(row, 'near', { searchableColumns: ['status.label'] })).toBe(true)
+    expect(rowMatchesSearch(row, 'near', { searchableColumns: ['name'] })).toBe(false)
+  })
+  it('honors a custom searchFn', () => {
+    expect(rowMatchesSearch(row, 'X', { searchFn: r => r.name.startsWith('HTTP') })).toBe(true)
+  })
+})

--- a/packages/datum-ui/src/components/features/data-table/core/filter-engine.ts
+++ b/packages/datum-ui/src/components/features/data-table/core/filter-engine.ts
@@ -75,16 +75,41 @@ function resolveStrategy(strategy: FilterStrategy | undefined): FilterFn | undef
   return FILTER_STRATEGIES[strategy]
 }
 
+export interface SearchConfig<TData> {
+  searchFn?: (row: TData, query: string) => boolean
+  searchableColumns?: string[]
+}
+
+/** True when a row matches a free-text query (custom fn → columns → all values). */
+export function rowMatchesSearch<TData>(
+  row: TData,
+  search: string,
+  config: SearchConfig<TData>,
+): boolean {
+  if (!search || search.length === 0)
+    return true
+  if (config.searchFn)
+    return config.searchFn(row, search)
+
+  const query = search.toLowerCase()
+  if (config.searchableColumns && config.searchableColumns.length > 0) {
+    return config.searchableColumns.some((col) => {
+      const cellValue = resolvePath(row, col)
+      return cellValue != null && String(cellValue).toLowerCase().includes(query)
+    })
+  }
+  return Object.values(row as Record<string, unknown>).some(
+    val => val != null && String(val).toLowerCase().includes(query),
+  )
+}
+
 export function applyFilters<TData>(
   data: TData[],
   filters: Record<string, unknown>,
   search: string,
   registeredFilters: Map<string, FilterStrategy>,
   customFilterFns: Record<string, FilterFn>,
-  searchConfig: {
-    searchFn?: (row: TData, query: string) => boolean
-    searchableColumns?: string[]
-  },
+  searchConfig: SearchConfig<TData>,
 ): TData[] {
   const hasFilters = Object.keys(filters).length > 0
   const hasSearch = search.length > 0
@@ -106,24 +131,8 @@ export function applyFilters<TData>(
       }
     }
 
-    if (hasSearch) {
-      const query = search.toLowerCase()
-      if (searchConfig.searchFn) {
-        return searchConfig.searchFn(row, search)
-      }
-      if (searchConfig.searchableColumns && searchConfig.searchableColumns.length > 0) {
-        return searchConfig.searchableColumns.some((col) => {
-          const cellValue = resolvePath(row, col)
-          return cellValue != null && String(cellValue).toLowerCase().includes(query)
-        })
-      }
-      // Fallback: search all string/number values on the row
-      return Object.values(row as Record<string, unknown>).some((val) => {
-        if (val == null)
-          return false
-        return String(val).toLowerCase().includes(query)
-      })
-    }
+    if (hasSearch && !rowMatchesSearch(row, search, searchConfig))
+      return false
 
     return true
   })

--- a/packages/datum-ui/src/components/features/data-table/index.ts
+++ b/packages/datum-ui/src/components/features/data-table/index.ts
@@ -5,6 +5,10 @@ export type { UseNuqsAdapterOptions } from './adapters/nuqs-adapter'
 // Columns
 export { createSelectionColumn } from './columns/selection-column'
 
+// Components (reusable, context-free)
+export { DataTableColumnHeader } from './components/column-header'
+export { DataTableRowActions } from './components/row-actions'
+
 // Constants
 export {
   DEFAULT_DEBOUNCE_MS,
@@ -12,6 +16,10 @@ export {
   DEFAULT_PAGE_SIZE,
   DEFAULT_PAGE_SIZES,
 } from './constants'
+// Search utilities (reused by grouped-table)
+export { resolvePath, rowMatchesSearch } from './core/filter-engine'
+
+export type { SearchConfig } from './core/filter-engine'
 // Store
 export { createDataTableStore } from './core/store'
 

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/bucket-rows.test.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/bucket-rows.test.ts
@@ -1,0 +1,25 @@
+import type { Row } from '@tanstack/react-table'
+import { describe, expect, it } from 'vitest'
+import { bucketRows } from '../lib/bucket-rows'
+
+const row = (id: string) => ({ id } as Row<unknown>)
+const groups = [
+  { id: 'g1', rows: [{}, {}] },
+  { id: 'g2', rows: [{}] },
+]
+// core rows in group-concatenated order: g1,g1,g2
+const coreRows = [row('0'), row('1'), row('2')]
+
+describe('bucketRows', () => {
+  it('buckets all rows by group when nothing is filtered', () => {
+    const out = bucketRows(groups, coreRows, coreRows)
+    expect(out.get('g1')!.map(r => r.id)).toEqual(['0', '1'])
+    expect(out.get('g2')!.map(r => r.id)).toEqual(['2'])
+  })
+  it('only places filtered rows into their group bucket', () => {
+    const filtered = [row('1'), row('2')] // row 0 filtered out
+    const out = bucketRows(groups, coreRows, filtered)
+    expect(out.get('g1')!.map(r => r.id)).toEqual(['1'])
+    expect(out.get('g2')!.map(r => r.id)).toEqual(['2'])
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/compose-columns.test.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/compose-columns.test.tsx
@@ -1,0 +1,38 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import { describe, expect, it } from 'vitest'
+import { composeColumns } from '../lib/compose-columns'
+
+interface Row { name: string }
+const base: ColumnDef<Row, unknown>[] = [{ accessorKey: 'name', header: 'Name', cell: i => i.getValue() as string }]
+
+describe('composeColumns', () => {
+  it('returns base columns unchanged when no options are set', () => {
+    expect(composeColumns(base, {})).toHaveLength(1)
+  })
+  it('prepends a selection column', () => {
+    const out = composeColumns(base, { enableRowSelection: true })
+    expect(out[0]?.id).toBe('select')
+    expect(out).toHaveLength(2)
+  })
+  it('appends an actions column when rowActions is set', () => {
+    const out = composeColumns(base, { rowActions: () => [] })
+    expect(out[out.length - 1]?.id).toBe('actions')
+  })
+  it('places selection first and actions last together', () => {
+    const out = composeColumns(base, { enableRowSelection: true, rowActions: () => [] })
+    expect(out[0]?.id).toBe('select')
+    expect(out[out.length - 1]?.id).toBe('actions')
+  })
+
+  it('wraps string headers as sortable when enableSorting is set', () => {
+    const out = composeColumns(base, { enableSorting: true })
+    expect(typeof out[0]?.header).toBe('function')
+    expect(out[0]?.enableSorting).toBe(true)
+  })
+
+  it('leaves columns with custom header renderers untouched', () => {
+    const custom: ColumnDef<Row, unknown>[] = [{ id: 'x', header: () => null, cell: () => null }]
+    const out = composeColumns(custom, { enableSorting: true })
+    expect(out[0]).toBe(custom[0]) // same reference — not modified
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-skeleton.test.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-skeleton.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { GroupedSkeleton } from '../components/grouped-skeleton'
+
+describe('groupedSkeleton', () => {
+  it('renders the requested number of group bands and rows', () => {
+    const { container } = render(<GroupedSkeleton columns={3} groups={2} rowsPerGroup={2} />)
+    expect(container.querySelectorAll('[data-slot="gt-skeleton-band"]')).toHaveLength(2)
+    expect(container.querySelectorAll('[data-slot="gt-skeleton-row"]')).toHaveLength(4)
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-table.test.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-table.test.tsx
@@ -1,0 +1,141 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import type { ColumnDef } from '@tanstack/react-table'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { GroupedTable } from '../grouped-table'
+
+interface Row { name: string, value: number }
+const columns: ColumnDef<Row, unknown>[] = [
+  { accessorKey: 'name', header: 'Resource', cell: info => info.getValue() as string, size: 160 },
+  { accessorKey: 'value', header: 'Value', cell: info => String(info.getValue()) },
+]
+const groups = [
+  { id: 'g1', title: 'Group One', meta: <span>2 items</span>, rows: [{ name: 'alpha', value: 1 }, { name: 'beta', value: 2 }] },
+  { id: 'g2', title: 'Group Two', rows: [{ name: 'gamma', value: 3 }] },
+]
+
+describe('groupedTable', () => {
+  it('renders group titles, meta, and rows (all expanded by default)', () => {
+    render(<GroupedTable columns={columns} groups={groups} />)
+    expect(screen.getByText('Group One')).toBeInTheDocument()
+    expect(screen.getByText('2 items')).toBeInTheDocument()
+    expect(screen.getByText('alpha')).toBeVisible()
+    expect(screen.getByText('gamma')).toBeVisible()
+  })
+
+  it('collapses a group when its header is clicked', () => {
+    render(<GroupedTable columns={columns} groups={groups} />)
+    fireEvent.click(screen.getByText('Group One'))
+    expect(screen.getByText('Group One').closest('button')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('respects defaultExpanded=\'none\'', () => {
+    render(<GroupedTable columns={columns} groups={groups} defaultExpanded="none" />)
+    expect(screen.getByText('Group One').closest('button')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('renders the empty slot when there are no rows', () => {
+    render(<GroupedTable columns={columns} groups={[]} empty={<div>No data</div>} />)
+    expect(screen.getByText('No data')).toBeInTheDocument()
+  })
+
+  it('controlled mode reflects the expanded prop and defers toggles to the parent', () => {
+    const onExpandedChange = vi.fn()
+    render(
+      <GroupedTable columns={columns} groups={groups} expanded={['g1']} onExpandedChange={onExpandedChange} />,
+    )
+    expect(screen.getByText('Group One').closest('button')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Group Two').closest('button')).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(screen.getByText('Group One'))
+    // Controlled: it asks the parent to close g1 but does not self-update.
+    expect(onExpandedChange).toHaveBeenCalledWith([])
+    expect(screen.getByText('Group One').closest('button')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('renders a column header row', () => {
+    render(<GroupedTable columns={columns} groups={groups} />)
+    expect(screen.getByText('Resource')).toBeInTheDocument()
+    expect(screen.getByText('Value')).toBeInTheDocument()
+  })
+
+  it('aligns header and group tables on identical colgroup widths', () => {
+    const { container } = render(<GroupedTable columns={columns} groups={groups} />)
+    const colgroups = container.querySelectorAll('colgroup')
+    expect(colgroups.length).toBeGreaterThanOrEqual(2) // header table + at least one group table
+    const widthsOf = (cg: Element) => Array.from(cg.querySelectorAll('col')).map(c => (c as HTMLElement).style.width)
+    const first = widthsOf(colgroups[0]!)
+    expect(first).toEqual(['160px', 'auto'])
+    for (const cg of Array.from(colgroups))
+      expect(widthsOf(cg)).toEqual(first)
+  })
+
+  it('wraps the table area in a horizontal-scroll track sized from columns', () => {
+    const { container } = render(<GroupedTable columns={columns} groups={groups} />)
+    const scroll = container.querySelector('.overflow-x-auto')
+    expect(scroll).toBeInTheDocument()
+    // single shared track so header + group tables scroll together and stay aligned
+    const track = scroll!.firstElementChild as HTMLElement
+    expect(track.style.minWidth).toBe('280px') // 160px (name) + 120px flex floor (value)
+  })
+
+  it('renders selection checkboxes and toggles a row', () => {
+    render(<GroupedTable columns={columns} groups={groups} enableRowSelection />)
+    const checkboxes = screen.getAllByLabelText('Select row')
+    expect(checkboxes.length).toBe(3)
+    fireEvent.click(checkboxes[0]!)
+    expect(checkboxes[0]!).toBeChecked()
+  })
+
+  it('sorts within a group, not across groups', () => {
+    render(<GroupedTable columns={columns} groups={groups} enableSorting />)
+    fireEvent.click(screen.getByRole('button', { name: /Sort by Resource/ }))
+    const cells = screen.getAllByText(/^(alpha|beta|gamma)$/).map(el => el.textContent)
+    expect(cells[cells.length - 1]).toBe('gamma') // group two stays last
+  })
+
+  it('renders row actions and fires a handler', () => {
+    const onClick = vi.fn()
+    render(<GroupedTable columns={columns} groups={groups} rowActions={() => [{ label: 'Edit', onClick }]} />)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Open menu' })[0]!)
+    fireEvent.click(screen.getByText('Edit'))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('filters rows by search and hides non-matching groups', async () => {
+    render(<GroupedTable columns={columns} groups={groups} enableSearch searchPlaceholder="Search" searchDebounceMs={0} />)
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'alpha' } })
+    await waitFor(() => expect(screen.queryByText('gamma')).not.toBeInTheDocument())
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('Group One')).toBeInTheDocument()
+    expect(screen.queryByText('Group Two')).not.toBeInTheDocument()
+  })
+
+  it('shows the empty slot when search matches nothing', async () => {
+    render(<GroupedTable columns={columns} groups={groups} enableSearch searchPlaceholder="Search" searchDebounceMs={0} empty={<div>No results</div>} />)
+    fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'zzzzz' } })
+    await screen.findByText('No results')
+  })
+
+  it('renders skeleton when isLoading', () => {
+    const { container } = render(<GroupedTable columns={columns} groups={groups} isLoading />)
+    expect(container.querySelector('[data-slot="gt-skeleton"]')).toBeInTheDocument()
+  })
+
+  it('controlled selection defers to parent', () => {
+    const onRowSelectionChange = vi.fn()
+    render(
+      <GroupedTable
+        columns={columns}
+        groups={groups}
+        enableRowSelection
+        rowSelection={{}}
+        onRowSelectionChange={onRowSelectionChange}
+        getRowId={r => r.name}
+      />,
+    )
+    fireEvent.click(screen.getAllByLabelText('Select row')[0]!)
+    expect(onRowSelectionChange).toHaveBeenCalled()
+    expect(screen.getAllByLabelText('Select row')[0]!).not.toBeChecked()
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-toolbar.test.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/grouped-toolbar.test.tsx
@@ -1,0 +1,13 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { GroupedToolbar } from '../components/grouped-toolbar'
+
+describe('groupedToolbar', () => {
+  it('debounces changes before calling onSearchChange', async () => {
+    const onSearchChange = vi.fn()
+    render(<GroupedToolbar search="" onSearchChange={onSearchChange} debounceMs={20} placeholder="Search resources" />)
+    fireEvent.change(screen.getByLabelText('Search resources'), { target: { value: 'http' } })
+    expect(onSearchChange).not.toHaveBeenCalledWith('http')
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith('http'))
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/sort-rows.test.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/sort-rows.test.ts
@@ -1,0 +1,33 @@
+import type { Row } from '@tanstack/react-table'
+import { describe, expect, it } from 'vitest'
+import { sortRows } from '../lib/sort-rows'
+
+// Minimal fake rows: sortRows only uses row.getValue(columnId).
+function fakeRow<T extends Record<string, unknown>>(values: T): Row<unknown> {
+  return { getValue: (id: string) => values[id] } as unknown as Row<unknown>
+}
+
+const rows = [
+  fakeRow({ name: 'beta', n: 2 }),
+  fakeRow({ name: 'alpha', n: 3 }),
+  fakeRow({ name: 'gamma', n: 1 }),
+]
+
+describe('sortRows', () => {
+  it('returns input unchanged when sorting is empty', () => {
+    expect(sortRows(rows, [])).toBe(rows)
+  })
+  it('sorts ascending by string column', () => {
+    const out = sortRows(rows, [{ id: 'name', desc: false }])
+    expect(out.map(r => r.getValue('name'))).toEqual(['alpha', 'beta', 'gamma'])
+  })
+  it('sorts descending by numeric column', () => {
+    const out = sortRows(rows, [{ id: 'n', desc: true }])
+    expect(out.map(r => r.getValue('n'))).toEqual([3, 2, 1])
+  })
+  it('does not mutate the input array', () => {
+    const copy = [...rows]
+    sortRows(rows, [{ id: 'n', desc: false }])
+    expect(rows).toEqual(copy)
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/use-controllable-state.test.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/use-controllable-state.test.ts
@@ -1,0 +1,27 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useControllableState } from '../lib/use-controllable-state'
+
+describe('useControllableState', () => {
+  it('uncontrolled: owns state and notifies', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useControllableState<number>(undefined, 0, onChange))
+    act(() => result.current[1](5))
+    expect(result.current[0]).toBe(5)
+    expect(onChange).toHaveBeenCalledWith(5)
+  })
+
+  it('uncontrolled: supports updater functions', () => {
+    const { result } = renderHook(() => useControllableState<number>(undefined, 1))
+    act(() => result.current[1](prev => prev + 1))
+    expect(result.current[0]).toBe(2)
+  })
+
+  it('controlled: reflects prop and does not self-update', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useControllableState<number>(10, 0, onChange))
+    act(() => result.current[1](99))
+    expect(onChange).toHaveBeenCalledWith(99)
+    expect(result.current[0]).toBe(10) // unchanged until parent updates the prop
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/__tests__/use-grouped-expansion.test.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/__tests__/use-grouped-expansion.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useGroupedExpansion } from '../use-grouped-expansion'
+
+const groups = [
+  { id: 'a', title: 'A', rows: [] },
+  { id: 'b', title: 'B', rows: [] },
+]
+
+describe('useGroupedExpansion', () => {
+  it('opens all by default (\'all\')', () => {
+    const { result } = renderHook(() => useGroupedExpansion(groups, {}))
+    expect(result.current.isOpen('a')).toBe(true)
+    expect(result.current.isOpen('b')).toBe(true)
+  })
+
+  it('opens none for \'none\'', () => {
+    const { result } = renderHook(() => useGroupedExpansion(groups, { defaultExpanded: 'none' }))
+    expect(result.current.isOpen('a')).toBe(false)
+  })
+
+  it('opens only listed ids for string[]', () => {
+    const { result } = renderHook(() => useGroupedExpansion(groups, { defaultExpanded: ['b'] }))
+    expect(result.current.isOpen('a')).toBe(false)
+    expect(result.current.isOpen('b')).toBe(true)
+  })
+
+  it('per-group defaultOpen overrides the table default', () => {
+    const g = [{ id: 'a', title: 'A', rows: [], defaultOpen: false }, { id: 'b', title: 'B', rows: [] }]
+    const { result } = renderHook(() => useGroupedExpansion(g, { defaultExpanded: 'all' }))
+    expect(result.current.isOpen('a')).toBe(false)
+    expect(result.current.isOpen('b')).toBe(true)
+  })
+
+  it('toggles in uncontrolled mode and notifies', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useGroupedExpansion(groups, { defaultExpanded: 'none', onExpandedChange: onChange }))
+    act(() => result.current.toggle('a'))
+    expect(result.current.isOpen('a')).toBe(true)
+    expect(onChange).toHaveBeenCalledWith(['a'])
+  })
+
+  it('opens async-arriving groups under defaultExpanded=all', () => {
+    const initial = [{ id: 'a', title: 'A', rows: [] }]
+    const { result, rerender } = renderHook(
+      ({ g }) => useGroupedExpansion(g, { defaultExpanded: 'all' }),
+      { initialProps: { g: initial } },
+    )
+    expect(result.current.isOpen('a')).toBe(true)
+    rerender({ g: [...initial, { id: 'b', title: 'B', rows: [] }] })
+    expect(result.current.isOpen('b')).toBe(true) // newly-arrived group inherits 'all'
+  })
+
+  it('controlled mode reflects expanded prop and does not self-update', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useGroupedExpansion(groups, { expanded: ['a'], onExpandedChange: onChange }))
+    expect(result.current.isOpen('a')).toBe(true)
+    act(() => result.current.toggle('a'))
+    expect(onChange).toHaveBeenCalledWith([]) // asks parent to close
+    expect(result.current.isOpen('a')).toBe(true) // still open until parent updates the prop
+  })
+})

--- a/packages/datum-ui/src/components/features/grouped-table/components/grouped-skeleton.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/components/grouped-skeleton.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from '../../../base/skeleton'
+
+export interface GroupedSkeletonProps {
+  columns?: number
+  groups?: number
+  rowsPerGroup?: number
+}
+
+export function GroupedSkeleton({ columns = 4, groups = 2, rowsPerGroup = 3 }: GroupedSkeletonProps) {
+  return (
+    <div data-slot="gt-skeleton">
+      {Array.from({ length: groups }, (_, g) => (
+        <div key={g}>
+          <div
+            data-slot="gt-skeleton-band"
+            className="flex items-center gap-2 bg-muted/40 px-3 py-2 [&:not(:first-child)]:border-t"
+          >
+            <Skeleton className="size-4 rounded" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          {Array.from({ length: rowsPerGroup }, (_, r) => (
+            <div
+              key={r}
+              data-slot="gt-skeleton-row"
+              className="flex items-center gap-3 px-3 py-2 [&:not(:last-child)]:border-b"
+            >
+              {Array.from({ length: columns }, (_, c) => (
+                <Skeleton key={c} className="h-4 w-full" />
+              ))}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/datum-ui/src/components/features/grouped-table/components/grouped-toolbar.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/components/grouped-toolbar.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { Input } from '../../../base/input'
+
+const DEFAULT_DEBOUNCE_MS = 300
+
+export interface GroupedToolbarProps {
+  search: string
+  onSearchChange: (value: string) => void
+  placeholder?: string
+  debounceMs?: number
+  className?: string
+}
+
+export function GroupedToolbar({
+  search,
+  onSearchChange,
+  placeholder = 'Search...',
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  className,
+}: GroupedToolbarProps) {
+  const [value, setValue] = useState(search)
+
+  useEffect(() => {
+    setValue(search)
+  }, [search])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (value !== search)
+        onSearchChange(value)
+    }, debounceMs)
+    return () => clearTimeout(timer)
+  }, [value, debounceMs, search, onSearchChange])
+
+  return (
+    <div className="pb-3" data-slot="gt-toolbar">
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        aria-label={placeholder}
+        className={className}
+        data-slot="gt-search"
+      />
+    </div>
+  )
+}

--- a/packages/datum-ui/src/components/features/grouped-table/grouped-table.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/grouped-table.tsx
@@ -1,0 +1,221 @@
+import type { ColumnDef, Row } from '@tanstack/react-table'
+import type { ReactNode } from 'react'
+import type { GroupedTableProps } from './types'
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { ChevronRight } from 'lucide-react'
+import { useMemo } from 'react'
+import { cn } from '../../../utils/cn'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../base/collapsible'
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../base/table'
+import { Icon } from '../../icons/icon-wrapper'
+import { rowMatchesSearch } from '../data-table'
+import { GroupedSkeleton } from './components/grouped-skeleton'
+import { GroupedToolbar } from './components/grouped-toolbar'
+import { bucketRows } from './lib/bucket-rows'
+import { composeColumns } from './lib/compose-columns'
+import { sortRows } from './lib/sort-rows'
+import { useControllableState } from './lib/use-controllable-state'
+import { useGroupedExpansion } from './use-grouped-expansion'
+
+/** Floor width for unsized (flex) columns so they keep their share instead of collapsing on narrow viewports. */
+const MIN_FLEX_COLUMN_WIDTH = 120
+
+function columnWidth<TData>(col: ColumnDef<TData, unknown>): string {
+  return typeof col.size === 'number' ? `${col.size}px` : 'auto'
+}
+
+/** Minimum width the table track needs so every column keeps a usable size; below this the area scrolls horizontally. */
+function trackMinWidth<TData>(resolvedColumns: ColumnDef<TData, unknown>[]): number {
+  return resolvedColumns.reduce(
+    (total, col) => total + (typeof col.size === 'number' ? col.size : MIN_FLEX_COLUMN_WIDTH),
+    0,
+  )
+}
+
+function renderColGroup<TData>(resolvedColumns: ColumnDef<TData, unknown>[]): ReactNode {
+  return (
+    <colgroup>
+      {resolvedColumns.map((col, i) => (
+        <col key={`col-${i}`} style={{ width: columnWidth(col) }} />
+      ))}
+    </colgroup>
+  )
+}
+
+export function GroupedTable<TData>(props: GroupedTableProps<TData>) {
+  const {
+    columns,
+    groups,
+    defaultExpanded,
+    expanded,
+    onExpandedChange,
+    getRowId,
+    enableRowSelection,
+    rowSelection: rowSelectionProp,
+    onRowSelectionChange,
+    rowActions,
+    rowActionsSheetTitle,
+    enableSorting,
+    sorting: sortingProp,
+    onSortingChange,
+    enableSearch,
+    searchPlaceholder,
+    searchableColumns,
+    searchFn,
+    search: searchProp,
+    onSearchChange,
+    searchDebounceMs,
+    isLoading,
+    empty,
+    className,
+  } = props
+
+  const [sorting, setSorting] = useControllableState(sortingProp, [], onSortingChange)
+  const [rowSelection, setRowSelection] = useControllableState(rowSelectionProp, {}, onRowSelectionChange)
+  const [search, setSearch] = useControllableState(searchProp, '', onSearchChange)
+  const isSearching = search.trim().length > 0
+
+  const { isOpen, toggle } = useGroupedExpansion(groups, { defaultExpanded, expanded, onExpandedChange })
+
+  const resolvedColumns = useMemo(
+    () => composeColumns(columns, { enableRowSelection, enableSorting, rowActions, rowActionsSheetTitle }),
+    [columns, enableRowSelection, enableSorting, rowActions, rowActionsSheetTitle],
+  )
+
+  const minWidth = useMemo(() => trackMinWidth(resolvedColumns), [resolvedColumns])
+
+  const flatData = useMemo(() => groups.flatMap(g => g.rows), [groups])
+
+  const table = useReactTable({
+    data: flatData,
+    columns: resolvedColumns,
+    state: { sorting, rowSelection, globalFilter: search },
+    onSortingChange: setSorting,
+    onRowSelectionChange: setRowSelection,
+    onGlobalFilterChange: setSearch,
+    enableRowSelection: Boolean(enableRowSelection),
+    manualSorting: true,
+    enableMultiSort: false,
+    globalFilterFn: (row, _columnId, value) =>
+      rowMatchesSearch(row.original as TData, String(value ?? ''), { searchFn, searchableColumns }),
+    getRowId,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
+  const headerGroups = table.getHeaderGroups()
+  const coreRows = table.getCoreRowModel().rows
+  const filteredRows = table.getRowModel().rows
+
+  const buckets = useMemo(
+    () => bucketRows(groups, coreRows, filteredRows),
+    [groups, coreRows, filteredRows],
+  )
+
+  const slices = useMemo(
+    () => groups.map(g => ({
+      id: g.id,
+      title: g.title,
+      meta: g.meta,
+      rows: sortRows(buckets.get(g.id) ?? [], sorting),
+    })),
+    [groups, buckets, sorting],
+  )
+  const visibleSlices = isSearching ? slices.filter(s => s.rows.length > 0) : slices
+
+  // `scrollable` wraps the tables in a single min-width track inside an x-scroll
+  // container, so on narrow viewports columns keep their widths and the whole
+  // grid (header + every group) scrolls together instead of collapsing/clipping.
+  const renderShell = (body: ReactNode, scrollable: boolean) => (
+    <div className={cn('w-full', className)}>
+      {enableSearch && (
+        <GroupedToolbar
+          search={search}
+          onSearchChange={setSearch}
+          placeholder={searchPlaceholder}
+          debounceMs={searchDebounceMs}
+        />
+      )}
+      <div className={cn('w-full rounded-md border', scrollable ? 'overflow-x-auto' : 'overflow-hidden')}>
+        {scrollable ? <div style={{ minWidth }}>{body}</div> : body}
+      </div>
+    </div>
+  )
+
+  if (isLoading)
+    return renderShell(<GroupedSkeleton columns={resolvedColumns.length} />, false)
+
+  if (flatData.length === 0 || (isSearching && visibleSlices.length === 0))
+    return renderShell(empty ?? null, false)
+
+  return renderShell(
+    <>
+      <table className="w-full table-fixed text-sm">
+        {renderColGroup(resolvedColumns)}
+        <TableHeader>
+          {headerGroups.map(hg => (
+            <TableRow key={hg.id}>
+              {hg.headers.map(header => (
+                <TableHead key={header.id} scope="col">
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+      </table>
+
+      {visibleSlices.map((slice, i) => {
+        const open = isSearching ? true : isOpen(slice.id)
+        return (
+          <Collapsible key={slice.id} open={open} onOpenChange={() => toggle(slice.id)}>
+            <CollapsibleTrigger
+              className={cn(
+                'flex w-full items-center gap-2 bg-muted/40 px-3 py-2 text-left text-sm font-semibold hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                i > 0 && 'border-t',
+              )}
+            >
+              <Icon
+                icon={ChevronRight}
+                aria-hidden
+                className={cn('size-4 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')}
+              />
+              <span>{slice.title}</span>
+              {slice.meta != null && (
+                <span className="ml-auto flex items-center gap-2 font-medium text-muted-foreground">{slice.meta}</span>
+              )}
+            </CollapsibleTrigger>
+
+            <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+              <table
+                className="w-full table-fixed border-t text-sm"
+                aria-label={typeof slice.title === 'string' ? slice.title : undefined}
+              >
+                {renderColGroup(resolvedColumns)}
+                <TableBody>
+                  {slice.rows.map((row: Row<TData>) => (
+                    <TableRow key={row.id} data-state={row.getIsSelected() ? 'selected' : undefined}>
+                      {row.getVisibleCells().map(cell => (
+                        <TableCell key={cell.id} className="truncate">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </table>
+            </CollapsibleContent>
+          </Collapsible>
+        )
+      })}
+    </>,
+    true,
+  )
+}

--- a/packages/datum-ui/src/components/features/grouped-table/index.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/index.ts
@@ -1,0 +1,2 @@
+export { GroupedTable } from './grouped-table'
+export type { DefaultExpanded, GroupedTableGroup, GroupedTableProps } from './types'

--- a/packages/datum-ui/src/components/features/grouped-table/lib/bucket-rows.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/lib/bucket-rows.ts
@@ -1,0 +1,34 @@
+import type { Row } from '@tanstack/react-table'
+
+interface GroupLike { id: string, rows: unknown[] }
+
+/**
+ * Build per-group buckets of `filteredRows`, preserving the filtered order.
+ * `coreRows` are the unfiltered rows in group-concatenated order; we use their
+ * positions to learn which row id belongs to which group, so bucketing is correct
+ * regardless of a custom getRowId.
+ */
+export function bucketRows<TData>(
+  groups: GroupLike[],
+  coreRows: Row<TData>[],
+  filteredRows: Row<TData>[],
+): Map<string, Row<TData>[]> {
+  const idToGroup = new Map<string, string>()
+  let offset = 0
+  for (const group of groups) {
+    for (let i = 0; i < group.rows.length; i++) {
+      const core = coreRows[offset + i]
+      if (core)
+        idToGroup.set(core.id, group.id)
+    }
+    offset += group.rows.length
+  }
+
+  const buckets = new Map<string, Row<TData>[]>(groups.map(g => [g.id, []]))
+  for (const row of filteredRows) {
+    const groupId = idToGroup.get(row.id)
+    if (groupId)
+      buckets.get(groupId)!.push(row)
+  }
+  return buckets
+}

--- a/packages/datum-ui/src/components/features/grouped-table/lib/compose-columns.tsx
+++ b/packages/datum-ui/src/components/features/grouped-table/lib/compose-columns.tsx
@@ -1,0 +1,58 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import type { SelectionColumnOptions } from '../../data-table/types'
+import type { ActionItem } from '../../more-actions/types'
+import { createSelectionColumn, DataTableColumnHeader, DataTableRowActions } from '../../data-table'
+
+export interface ComposeOptions<TData> {
+  enableRowSelection?: boolean | SelectionColumnOptions
+  enableSorting?: boolean
+  rowActions?: (row: TData) => ActionItem<TData>[]
+  rowActionsSheetTitle?: string
+}
+
+/** Wrap plain string headers in the sortable header; leave all other columns untouched. */
+function withSortableHeaders<TData>(columns: ColumnDef<TData, unknown>[]): ColumnDef<TData, unknown>[] {
+  return columns.map((col) => {
+    if (typeof col.header !== 'string')
+      return col
+    const title = col.header
+    return {
+      ...col,
+      enableSorting: col.enableSorting ?? true,
+      header: ({ column }) => <DataTableColumnHeader column={column} title={title} />,
+    } as ColumnDef<TData, unknown>
+  })
+}
+
+export function composeColumns<TData>(
+  columns: ColumnDef<TData, unknown>[],
+  options: ComposeOptions<TData>,
+): ColumnDef<TData, unknown>[] {
+  const { enableRowSelection, enableSorting, rowActions, rowActionsSheetTitle } = options
+  let cols = columns
+
+  if (enableSorting)
+    cols = withSortableHeaders(cols)
+
+  if (enableRowSelection) {
+    const selOpts = typeof enableRowSelection === 'object' ? enableRowSelection : {}
+    cols = [createSelectionColumn<TData>(selOpts) as ColumnDef<TData, unknown>, ...cols]
+  }
+
+  if (rowActions) {
+    cols = [...cols, {
+      id: 'actions',
+      size: 44,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <DataTableRowActions
+          row={row}
+          actions={rowActions(row.original)}
+          sheetTitle={rowActionsSheetTitle}
+        />
+      ),
+    }]
+  }
+
+  return cols
+}

--- a/packages/datum-ui/src/components/features/grouped-table/lib/sort-rows.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/lib/sort-rows.ts
@@ -1,0 +1,27 @@
+import type { Row, SortingState } from '@tanstack/react-table'
+
+function compare(a: unknown, b: unknown): number {
+  if (a == null && b == null)
+    return 0
+  if (a == null)
+    return -1
+  if (b == null)
+    return 1
+  if (typeof a === 'number' && typeof b === 'number')
+    return a - b
+  return String(a).localeCompare(String(b))
+}
+
+/**
+ * Sort a single group's rows by the active sort (first entry; v1 is single-sort).
+ * Returns the same reference when there is no sort, so React can skip re-renders.
+ */
+export function sortRows<TData>(rows: Row<TData>[], sorting: SortingState): Row<TData>[] {
+  if (sorting.length === 0)
+    return rows
+  const { id, desc } = sorting[0]!
+  const sorted = [...rows].sort((ra, rb) => compare(ra.getValue(id), rb.getValue(id)))
+  if (desc)
+    sorted.reverse()
+  return sorted
+}

--- a/packages/datum-ui/src/components/features/grouped-table/lib/use-controllable-state.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/lib/use-controllable-state.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react'
+
+export type Updater<T> = T | ((prev: T) => T)
+
+/**
+ * Uncontrolled-by-default state with an optional controlled override.
+ * When `controlled` is undefined the hook owns the value; otherwise the prop wins.
+ * `onChange` always fires. Accepts TanStack-style updater functions.
+ */
+export function useControllableState<T>(
+  controlled: T | undefined,
+  defaultValue: T,
+  onChange?: (value: T) => void,
+): readonly [T, (next: Updater<T>) => void] {
+  const [internal, setInternal] = useState<T>(defaultValue)
+  const isControlled = controlled !== undefined
+  const value: T = isControlled ? controlled : internal
+
+  const setValue = useCallback(
+    (next: Updater<T>) => {
+      const resolved
+        = typeof next === 'function' ? (next as (prev: T) => T)(value) : next
+      if (!isControlled)
+        setInternal(resolved)
+      onChange?.(resolved)
+    },
+    [isControlled, onChange, value],
+  )
+
+  return [value, setValue] as const
+}

--- a/packages/datum-ui/src/components/features/grouped-table/types.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/types.ts
@@ -1,0 +1,65 @@
+import type { ColumnDef, RowSelectionState, SortingState } from '@tanstack/react-table'
+import type { ReactNode } from 'react'
+import type { SelectionColumnOptions } from '../data-table/types'
+import type { ActionItem } from '../more-actions/types'
+
+export type DefaultExpanded = 'all' | 'none' | string[]
+
+export interface GroupedTableGroup<TData> {
+  /** Stable key used for expand state. */
+  id: string
+  /** Group header label. */
+  title: ReactNode
+  /** Right-aligned header slot — count, badges, actions. */
+  meta?: ReactNode
+  rows: TData[]
+  /** Per-group override of the table-level default. */
+  defaultOpen?: boolean
+}
+
+export interface GroupedTableProps<TData> {
+  /** TanStack column defs. `size` (px) drives the shared grid template; unsized columns flex. */
+  columns: ColumnDef<TData, unknown>[]
+  groups: GroupedTableGroup<TData>[]
+  /** Uncontrolled initial state. Default `'all'`. A string[] opens exactly those ids. */
+  defaultExpanded?: DefaultExpanded
+  /** Controlled open ids. When set, the component does not own expansion state. */
+  expanded?: string[]
+  onExpandedChange?: (openIds: string[]) => void
+  /**
+   * Stable row identity, passed through to TanStack. Supply this when consumers
+   * reorder rows or groups so React keys stay stable across renders instead of
+   * defaulting to the flattened row index.
+   */
+  getRowId?: (row: TData, index: number) => string
+
+  /** Prepend a checkbox column; pass options to customize. */
+  enableRowSelection?: boolean | SelectionColumnOptions
+  rowSelection?: RowSelectionState
+  onRowSelectionChange?: (selection: RowSelectionState) => void
+
+  /** Append a "⋯" actions column. Receives the row to allow conditional actions. */
+  rowActions?: (row: TData) => ActionItem<TData>[]
+  rowActionsSheetTitle?: string
+
+  /** Enable sortable headers; sorting is applied within each group. */
+  enableSorting?: boolean
+  sorting?: SortingState
+  onSortingChange?: (sorting: SortingState) => void
+
+  /** Render a built-in debounced search input above the table. */
+  enableSearch?: boolean
+  searchPlaceholder?: string
+  searchableColumns?: string[]
+  searchFn?: (row: TData, query: string) => boolean
+  search?: string
+  onSearchChange?: (search: string) => void
+  searchDebounceMs?: number
+
+  /** Render a skeleton instead of rows. */
+  isLoading?: boolean
+
+  /** Rendered when there are no groups, every group is empty, or search clears everything. */
+  empty?: ReactNode
+  className?: string
+}

--- a/packages/datum-ui/src/components/features/grouped-table/use-grouped-expansion.ts
+++ b/packages/datum-ui/src/components/features/grouped-table/use-grouped-expansion.ts
@@ -1,0 +1,42 @@
+import type { DefaultExpanded, GroupedTableGroup } from './types'
+import { useCallback, useState } from 'react'
+
+function defaultFor<TData>(group: GroupedTableGroup<TData>, def: DefaultExpanded): boolean {
+  const fallback
+    = def === 'all'
+      ? true
+      : def === 'none'
+        ? false
+        : Array.isArray(def) ? def.includes(group.id) : true
+  return group.defaultOpen ?? fallback
+}
+
+export function useGroupedExpansion<TData>(
+  groups: GroupedTableGroup<TData>[],
+  opts: { defaultExpanded?: DefaultExpanded, expanded?: string[], onExpandedChange?: (ids: string[]) => void },
+) {
+  const { defaultExpanded = 'all', expanded, onExpandedChange } = opts
+  const controlled = expanded !== undefined
+  // Explicit user toggles only; groups not present here fall back to their default,
+  // so async-arriving groups inherit `defaultExpanded` instead of being collapsed.
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({})
+
+  const isOpen = useCallback((id: string): boolean => {
+    if (controlled)
+      return expanded!.includes(id)
+    if (id in overrides)
+      return overrides[id]!
+    const g = groups.find(x => x.id === id)
+    return g ? defaultFor(g, defaultExpanded) : false
+  }, [controlled, expanded, overrides, groups, defaultExpanded])
+
+  const toggle = useCallback((id: string) => {
+    const now = isOpen(id)
+    if (!controlled)
+      setOverrides(o => ({ ...o, [id]: !now }))
+    const next = groups.filter(g => (g.id === id ? !now : isOpen(g.id))).map(g => g.id)
+    onExpandedChange?.(next)
+  }, [controlled, groups, isOpen, onExpandedChange])
+
+  return { isOpen, toggle }
+}

--- a/packages/datum-ui/tsdown.config.ts
+++ b/packages/datum-ui/tsdown.config.ts
@@ -91,6 +91,7 @@ export default defineConfig({
     'picker/index': 'src/components/features/picker/index.ts',
     'time-picker/index': 'src/components/features/time-picker/index.ts',
     'transfer/index': 'src/components/features/transfer/index.ts',
+    'grouped-table/index': 'src/components/features/grouped-table/index.ts',
   },
   format: ['esm'],
   dts: false,


### PR DESCRIPTION
## GroupedTable — collapsible grouped table with data-table parity

A domain-agnostic `features/grouped-table` component: banded, **collapsible** group sections that now look and behave like `data-table` — real column headers, sortable headers, checkbox multi-select, per-row action menus, search, and loading/empty states — while keeping per-group collapse and a slot-driven API. First consumer is the cloud-portal Quotas page, but the component carries zero quota/domain knowledge.

### API
```ts
<GroupedTable<TData>
  columns={ColumnDef<TData>[]}        // size (px) → shared <colgroup> widths; unsized → auto
  groups={[{ id, title, meta?, rows, defaultOpen? }]}
  defaultExpanded={'all' | 'none' | string[]}        // default 'all'
  expanded? onExpandedChange?                         // controlled expansion
  getRowId?                                           // stable row identity

  enableRowSelection? rowSelection? onRowSelectionChange?   // checkbox multi-select
  rowActions={(row) => ActionItem[]} rowActionsSheetTitle?  // ⋯ per-row menu
  enableSorting? sorting? onSortingChange?                  // sortable headers (within-group)
  enableSearch? searchPlaceholder? searchableColumns? searchFn? search? onSearchChange? searchDebounceMs?
  isLoading?                                          // skeleton
  empty? className?
/>
```

### How it works
- Renders a shared header `<table>` + one `<table>` per group (each a Radix `Collapsible` — animated, accessible disclosure). All tables share an identical `<colgroup>` with `table-layout: fixed`, so columns align across header and every group.
- One TanStack instance drives headers, selection, and search (`getFilteredRowModel` + a `globalFilterFn` = the reused `rowMatchesSearch`). Sorting uses `manualSorting` + `enableMultiSort: false` and is applied **per group** so it never crosses group boundaries.
- Selection / sorting / search are each **uncontrolled-by-default with a controlled option**, via a shared `useControllableState` (mirrors the existing expansion API).
- While searching: groups with no matches are hidden and matching groups are force-expanded; clearing search restores prior expansion. Select-all respects the active query.
- Reuses data-table primitives (`createSelectionColumn`, `DataTableColumnHeader`, `DataTableRowActions`, `rowMatchesSearch`) via barrel exports — no duplication.

### Tests & gates
- **249** vitest tests across grouped-table + data-table (helpers, hook, and component: headers, within-group sort, selection + controlled mode, row actions, search hide/auto-expand, empty, skeleton, colgroup alignment).
- Green: `pnpm typecheck`, `pnpm vitest run`, `pnpm lint`, `pnpm build` (emits `dist/grouped-table/`). Changeset: **minor**.

### Review notes (non-blocking)
- Visual/animation + screen-reader pass best done interactively in Storybook (Default / Sortable / Selectable / WithRowActions / Searchable / FullFeatured / Loading / Empty), light + dark.
- By design (v1): global select-all only (no per-group select-all); single-column sort; no filters/pagination/bulk-action bar (those live in `data-table`). Select-all spans matching rows including collapsed groups.